### PR TITLE
format code to ruff format.

### DIFF
--- a/src/neat3p/__init__.py
+++ b/src/neat3p/__init__.py
@@ -1,24 +1,23 @@
 """A NEAT (NeuroEvolution of Augmenting Topologies) implementation"""
-from ._neat3p import GenomeConfig, DefaultNodeGene
 
-from .utils import this_is_neat
+from ._neat3p import DefaultNodeGene, GenomeConfig
+from .checkpoint import Checkpointer
 
 # import .nn as nn
 # import .ctrnn as ctrnn
 # import .iznn as iznn
 # import .distributed as distributed
-
 from .config import Config
-from .population import Population, CompleteExtinctionException
-from .genome import DefaultGenome
-from .reproduction import DefaultReproduction
-from .stagnation import DefaultStagnation
-from .reporting import StdOutReporter
-from .species import DefaultSpeciesSet
-from .statistics import StatisticsReporter
-from .parallel import ParallelEvaluator
 from .distributed import DistributedEvaluator, host_is_local
+from .genome import DefaultGenome
+from .parallel import ParallelEvaluator
+from .population import CompleteExtinctionException, Population
+from .reporting import StdOutReporter
+from .reproduction import DefaultReproduction
+from .species import DefaultSpeciesSet
+from .stagnation import DefaultStagnation
+from .statistics import StatisticsReporter
 from .threaded import ThreadedEvaluator
-from .checkpoint import Checkpointer
+from .utils import this_is_neat
 
 __all__ = ["GenomeConfig", "DefaultNodeGene"]

--- a/src/neat3p/activations.py
+++ b/src/neat3p/activations.py
@@ -25,7 +25,7 @@ def sin_activation(z):
 
 def gauss_activation(z):
     z = max(-3.4, min(3.4, z))
-    return math.exp(-5.0 * z ** 2)
+    return math.exp(-5.0 * z**2)
 
 
 def relu_activation(z):
@@ -88,11 +88,11 @@ def hat_activation(z):
 
 
 def square_activation(z):
-    return z ** 2
+    return z**2
 
 
 def cube_activation(z):
-    return z ** 3
+    return z**3
 
 
 class InvalidActivationFunction(TypeError):
@@ -100,10 +100,7 @@ class InvalidActivationFunction(TypeError):
 
 
 def validate_activation(function):
-    if not isinstance(function,
-                      (types.BuiltinFunctionType,
-                       types.FunctionType,
-                       types.LambdaType)):
+    if not isinstance(function, (types.BuiltinFunctionType, types.FunctionType, types.LambdaType)):
         raise InvalidActivationFunction("A function object is required.")
 
     if function.__code__.co_argcount != 1:  # avoid deprecated use of `inspect`
@@ -118,24 +115,24 @@ class ActivationFunctionSet(object):
 
     def __init__(self):
         self.functions = {}
-        self.add('sigmoid', sigmoid_activation)
-        self.add('tanh', tanh_activation)
-        self.add('sin', sin_activation)
-        self.add('gauss', gauss_activation)
-        self.add('relu', relu_activation)
-        self.add('elu', elu_activation)
-        self.add('lelu', lelu_activation)
-        self.add('selu', selu_activation)
-        self.add('softplus', softplus_activation)
-        self.add('identity', identity_activation)
-        self.add('clamped', clamped_activation)
-        self.add('inv', inv_activation)
-        self.add('log', log_activation)
-        self.add('exp', exp_activation)
-        self.add('abs', abs_activation)
-        self.add('hat', hat_activation)
-        self.add('square', square_activation)
-        self.add('cube', cube_activation)
+        self.add("sigmoid", sigmoid_activation)
+        self.add("tanh", tanh_activation)
+        self.add("sin", sin_activation)
+        self.add("gauss", gauss_activation)
+        self.add("relu", relu_activation)
+        self.add("elu", elu_activation)
+        self.add("lelu", lelu_activation)
+        self.add("selu", selu_activation)
+        self.add("softplus", softplus_activation)
+        self.add("identity", identity_activation)
+        self.add("clamped", clamped_activation)
+        self.add("inv", inv_activation)
+        self.add("log", log_activation)
+        self.add("exp", exp_activation)
+        self.add("abs", abs_activation)
+        self.add("hat", hat_activation)
+        self.add("square", square_activation)
+        self.add("cube", cube_activation)
 
     def add(self, name, function):
         validate_activation(function)

--- a/src/neat3p/aggregations.py
+++ b/src/neat3p/aggregations.py
@@ -44,10 +44,7 @@ class InvalidAggregationFunction(TypeError):
 
 
 def validate_aggregation(function):  # TODO: Recognize when need `reduce`
-    if not isinstance(function,
-                      (types.BuiltinFunctionType,
-                       types.FunctionType,
-                       types.LambdaType)):
+    if not isinstance(function, (types.BuiltinFunctionType, types.FunctionType, types.LambdaType)):
         raise InvalidAggregationFunction("A function object is required.")
 
     if not (function.__code__.co_argcount >= 1):
@@ -59,13 +56,13 @@ class AggregationFunctionSet(object):
 
     def __init__(self):
         self.functions = {}
-        self.add('product', product_aggregation)
-        self.add('sum', sum_aggregation)
-        self.add('max', max_aggregation)
-        self.add('min', min_aggregation)
-        self.add('maxabs', maxabs_aggregation)
-        self.add('median', median_aggregation)
-        self.add('mean', mean_aggregation)
+        self.add("product", product_aggregation)
+        self.add("sum", sum_aggregation)
+        self.add("max", max_aggregation)
+        self.add("min", min_aggregation)
+        self.add("maxabs", maxabs_aggregation)
+        self.add("median", median_aggregation)
+        self.add("mean", mean_aggregation)
 
     def add(self, name, function):
         validate_aggregation(function)
@@ -79,8 +76,7 @@ class AggregationFunctionSet(object):
         return f
 
     def __getitem__(self, index):
-        warnings.warn("Use get, not indexing ([{!r}]), for aggregation functions".format(index),
-                      DeprecationWarning)
+        warnings.warn("Use get, not indexing ([{!r}]), for aggregation functions".format(index), DeprecationWarning)
         return self.get(index)
 
     def is_valid(self, name):

--- a/src/neat3p/attributes.py
+++ b/src/neat3p/attributes.py
@@ -1,8 +1,8 @@
 """Deals with the attributes (variable parameters) of genes"""
-from random import choice, gauss, random, uniform, randint
+
+from random import choice, gauss, randint, random, uniform
 
 from .config import ConfigParameter
-
 
 # TODO: There is probably a lot of room for simplification of these classes using metaprogramming.
 
@@ -22,8 +22,7 @@ class BaseAttribute(object):
         return f"{self.name}_{config_item_base_name}"
 
     def get_config_params(self):
-        return [ConfigParameter(self.config_item_name(n), ci[0], ci[1])
-                for n, ci in self._config_items.items()]
+        return [ConfigParameter(self.config_item_name(n), ci[0], ci[1]) for n, ci in self._config_items.items()]
 
 
 class FloatAttribute(BaseAttribute):
@@ -31,14 +30,17 @@ class FloatAttribute(BaseAttribute):
     Class for floating-point numeric attributes,
     such as the response of a node or the weight of a connection.
     """
-    _config_items = {"init_mean": [float, None],
-                     "init_stdev": [float, None],
-                     "init_type": [str, 'gaussian'],
-                     "replace_rate": [float, None],
-                     "mutate_rate": [float, None],
-                     "mutate_power": [float, None],
-                     "max_value": [float, None],
-                     "min_value": [float, None]}
+
+    _config_items = {
+        "init_mean": [float, None],
+        "init_stdev": [float, None],
+        "init_type": [str, "gaussian"],
+        "replace_rate": [float, None],
+        "mutate_rate": [float, None],
+        "mutate_power": [float, None],
+        "max_value": [float, None],
+        "min_value": [float, None],
+    }
 
     def clamp(self, value, config):
         min_value = getattr(config, self.min_value_name)
@@ -50,14 +52,12 @@ class FloatAttribute(BaseAttribute):
         stdev = getattr(config, self.init_stdev_name)
         init_type = getattr(config, self.init_type_name).lower()
 
-        if ('gauss' in init_type) or ('normal' in init_type):
+        if ("gauss" in init_type) or ("normal" in init_type):
             return self.clamp(gauss(mean, stdev), config)
 
-        if 'uniform' in init_type:
-            min_value = max(getattr(config, self.min_value_name),
-                            (mean - (2 * stdev)))
-            max_value = min(getattr(config, self.max_value_name),
-                            (mean + (2 * stdev)))
+        if "uniform" in init_type:
+            min_value = max(getattr(config, self.min_value_name), (mean - (2 * stdev)))
+            max_value = min(getattr(config, self.max_value_name), (mean + (2 * stdev)))
             return uniform(min_value, max_value)
 
         raise RuntimeError(f"Unknown init_type {getattr(config, self.init_type_name)!r} for {self.init_type_name!s}")
@@ -90,11 +90,14 @@ class IntegerAttribute(BaseAttribute):
     """
     Class for integer numeric attributes.
     """
-    _config_items = {"replace_rate": [float, None],
-                     "mutate_rate": [float, None],
-                     "mutate_power": [float, None],
-                     "max_value": [int, None],
-                     "min_value": [int, None]}
+
+    _config_items = {
+        "replace_rate": [float, None],
+        "mutate_rate": [float, None],
+        "mutate_power": [float, None],
+        "max_value": [int, None],
+        "min_value": [int, None],
+    }
 
     def clamp(self, value, config):
         min_value = getattr(config, self.min_value_name)
@@ -129,21 +132,25 @@ class IntegerAttribute(BaseAttribute):
         if max_value < min_value:
             raise RuntimeError(f"Invalid min/max configuration for {self.name}")
 
+
 class BoolAttribute(BaseAttribute):
     """Class for boolean attributes such as whether a connection is enabled or not."""
-    _config_items = {"default": [str, None],
-                     "mutate_rate": [float, None],
-                     "rate_to_true_add": [float, 0.0],
-                     "rate_to_false_add": [float, 0.0]}
+
+    _config_items = {
+        "default": [str, None],
+        "mutate_rate": [float, None],
+        "rate_to_true_add": [float, 0.0],
+        "rate_to_false_add": [float, 0.0],
+    }
 
     def init_value(self, config):
         default = str(getattr(config, self.default_name)).lower()
 
-        if default in ('1', 'on', 'yes', 'true'):
+        if default in ("1", "on", "yes", "true"):
             return True
-        elif default in ('0', 'off', 'no', 'false'):
+        elif default in ("0", "off", "no", "false"):
             return False
-        elif default in ('random', 'none'):
+        elif default in ("random", "none"):
             return bool(random() < 0.5)
 
         raise RuntimeError(f"Unknown default value {default!r} for {self.name!s}")
@@ -169,22 +176,22 @@ class BoolAttribute(BaseAttribute):
 
     def validate(self, config):
         default = str(getattr(config, self.default_name)).lower()
-        if default not in ('1', 'on', 'yes', 'true', '0', 'off', 'no', 'false', 'random', 'none'):
+        if default not in ("1", "on", "yes", "true", "0", "off", "no", "false", "random", "none"):
             raise RuntimeError(f"Invalid default value for {self.name}")
+
 
 class StringAttribute(BaseAttribute):
     """
     Class for string attributes such as the aggregation function of a node,
     which are selected from a list of options.
     """
-    _config_items = {"default": [str, 'random'],
-                     "options": [list, None],
-                     "mutate_rate": [float, None]}
+
+    _config_items = {"default": [str, "random"], "options": [list, None], "mutate_rate": [float, None]}
 
     def init_value(self, config):
         default = getattr(config, self.default_name)
 
-        if default.lower() in ('none', 'random'):
+        if default.lower() in ("none", "random"):
             options = getattr(config, self.options_name)
             return choice(options)
 
@@ -203,8 +210,8 @@ class StringAttribute(BaseAttribute):
 
     def validate(self, config):
         default = getattr(config, self.default_name)
-        if default not in ('none', 'random'):
+        if default not in ("none", "random"):
             options = getattr(config, self.options_name)
             if default not in options:
-                raise RuntimeError(f'Invalid initial value {default} for {self.name}')
+                raise RuntimeError(f"Invalid initial value {default} for {self.name}")
             assert default in options

--- a/src/neat3p/checkpoint.py
+++ b/src/neat3p/checkpoint.py
@@ -15,8 +15,7 @@ class Checkpointer(BaseReporter):
     to save and restore populations (and other aspects of the simulation state).
     """
 
-    def __init__(self, generation_interval=100, time_interval_seconds=300,
-                 filename_prefix='neat-checkpoint-'):
+    def __init__(self, generation_interval=100, time_interval_seconds=300, filename_prefix="neat-checkpoint-"):
         """
         Saves the current state (at the end of a generation) every ``generation_interval`` generations or
         ``time_interval_seconds``, whichever happens first.
@@ -57,11 +56,11 @@ class Checkpointer(BaseReporter):
             self.last_time_checkpoint = time.time()
 
     def save_checkpoint(self, config, population, species_set, generation):
-        """ Save the current simulation state. """
-        filename = '{0}{1}'.format(self.filename_prefix, generation)
+        """Save the current simulation state."""
+        filename = "{0}{1}".format(self.filename_prefix, generation)
         print("Saving checkpoint to {0}".format(filename))
 
-        with gzip.open(filename, 'w', compresslevel=5) as f:
+        with gzip.open(filename, "w", compresslevel=5) as f:
             data = (generation, config, population, species_set, random.getstate())
             pickle.dump(data, f, protocol=pickle.HIGHEST_PROTOCOL)
 

--- a/src/neat3p/config.py
+++ b/src/neat3p/config.py
@@ -41,7 +41,7 @@ class ConfigParameter(object):
         value = config_dict.get(self.name)
         if value is None:
             if self.default is None:
-                raise RuntimeError('Missing configuration item: ' + self.name)
+                raise RuntimeError("Missing configuration item: " + self.name)
             else:
                 warnings.warn(f"Using default {self.default!r} for '{self.name!s}'", DeprecationWarning)
                 if (str != self.value_type) and isinstance(self.default, self.value_type):
@@ -67,7 +67,8 @@ class ConfigParameter(object):
                 return value.split(" ")
         except Exception:
             raise RuntimeError(
-                f"Error interpreting config item '{self.name}' with value {value!r} and type {self.value_type}")
+                f"Error interpreting config item '{self.name}' with value {value!r} and type {self.value_type}"
+            )
 
         raise RuntimeError("Unexpected configuration type: " + repr(self.value_type))
 
@@ -85,11 +86,12 @@ def write_pretty_params(f, config, params):
 
     for name in param_names:
         p = params[name]
-        f.write(f'{p.name.ljust(longest_name)} = {p.format(getattr(config, p.name))}\n')
+        f.write(f"{p.name.ljust(longest_name)} = {p.format(getattr(config, p.name))}\n")
 
 
 class UnknownConfigItemError(NameError):
     """Error for unknown configuration option - partially to catch typos."""
+
     pass
 
 
@@ -108,8 +110,7 @@ class DefaultClassConfig(object):
         unknown_list = [x for x in param_dict if x not in param_list_names]
         if unknown_list:
             if len(unknown_list) > 1:
-                raise UnknownConfigItemError("Unknown configuration items:\n" +
-                                             "\n\t".join(unknown_list))
+                raise UnknownConfigItemError("Unknown configuration items:\n" + "\n\t".join(unknown_list))
             raise UnknownConfigItemError(f"Unknown configuration item {unknown_list[0]!s}")
 
     @classmethod
@@ -121,18 +122,22 @@ class DefaultClassConfig(object):
 class Config(object):
     """A container for user-configurable parameters of NEAT."""
 
-    __params = [ConfigParameter('pop_size', int),
-                ConfigParameter('fitness_criterion', str),
-                ConfigParameter('fitness_threshold', float),
-                ConfigParameter('reset_on_extinction', bool),
-                ConfigParameter('no_fitness_termination', bool, False)]
+    __params = [
+        ConfigParameter("pop_size", int),
+        ConfigParameter("fitness_criterion", str),
+        ConfigParameter("fitness_threshold", float),
+        ConfigParameter("reset_on_extinction", bool),
+        ConfigParameter("no_fitness_termination", bool, False),
+    ]
 
-    def __init__(self, genome_type, reproduction_type, species_set_type, stagnation_type, filename, config_information=None):
+    def __init__(
+        self, genome_type, reproduction_type, species_set_type, stagnation_type, filename, config_information=None
+    ):
         # Check that the provided types have the required methods.
-        assert hasattr(genome_type, 'parse_config')
-        assert hasattr(reproduction_type, 'parse_config')
-        assert hasattr(species_set_type, 'parse_config')
-        assert hasattr(stagnation_type, 'parse_config')
+        assert hasattr(genome_type, "parse_config")
+        assert hasattr(reproduction_type, "parse_config")
+        assert hasattr(species_set_type, "parse_config")
+        assert hasattr(stagnation_type, "parse_config")
 
         self.genome_type = genome_type
         self.reproduction_type = reproduction_type
@@ -141,33 +146,34 @@ class Config(object):
         self.config_information = config_information
 
         if not os.path.isfile(filename):
-            raise Exception('No such config file: ' + os.path.abspath(filename))
+            raise Exception("No such config file: " + os.path.abspath(filename))
 
         parameters = ConfigParser()
         with open(filename) as f:
             parameters.read_file(f)
 
         # NEAT configuration
-        if not parameters.has_section('NEAT'):
+        if not parameters.has_section("NEAT"):
             raise RuntimeError("'NEAT' section not found in NEAT configuration file.")
 
         param_list_names = []
         for p in self.__params:
             if p.default is None:
-                setattr(self, p.name, p.parse('NEAT', parameters))
+                setattr(self, p.name, p.parse("NEAT", parameters))
             else:
                 try:
-                    setattr(self, p.name, p.parse('NEAT', parameters))
+                    setattr(self, p.name, p.parse("NEAT", parameters))
                 except Exception:
                     setattr(self, p.name, p.default)
-                    warnings.warn(f"Using default {p.default!r} for '{p.name!s}'",
-                                  DeprecationWarning)
+                    warnings.warn(f"Using default {p.default!r} for '{p.name!s}'", DeprecationWarning)
             param_list_names.append(p.name)
-        param_dict = dict(parameters.items('NEAT'))
+        param_dict = dict(parameters.items("NEAT"))
         unknown_list = [x for x in param_dict if x not in param_list_names]
         if unknown_list:
             if len(unknown_list) > 1:
-                raise UnknownConfigItemError("Unknown (section 'NEAT') configuration items:\n" + "\n\t".join(unknown_list))
+                raise UnknownConfigItemError(
+                    "Unknown (section 'NEAT') configuration items:\n" + "\n\t".join(unknown_list)
+                )
             raise UnknownConfigItemError(f"Unknown (section 'NEAT') configuration item {unknown_list[0]!s}")
 
         # Parse type sections.
@@ -184,20 +190,20 @@ class Config(object):
         self.reproduction_config = reproduction_type.parse_config(reproduction_dict)
 
     def save(self, filename):
-        with open(filename, 'w') as f:
-            f.write('# The `NEAT` section specifies parameters particular to the NEAT algorithm\n')
-            f.write('# or the experiment itself.  This is the only required section.\n')
-            f.write('[NEAT]\n')
+        with open(filename, "w") as f:
+            f.write("# The `NEAT` section specifies parameters particular to the NEAT algorithm\n")
+            f.write("# or the experiment itself.  This is the only required section.\n")
+            f.write("[NEAT]\n")
             write_pretty_params(f, self, self.__params)
 
-            f.write(f'\n[{self.genome_type.__name__}]\n')
+            f.write(f"\n[{self.genome_type.__name__}]\n")
             self.genome_type.write_config(f, self.genome_config)
 
-            f.write(f'\n[{self.species_set_type.__name__}]\n')
+            f.write(f"\n[{self.species_set_type.__name__}]\n")
             self.species_set_type.write_config(f, self.species_set_config)
 
-            f.write(f'\n[{self.stagnation_type.__name__}]\n')
+            f.write(f"\n[{self.stagnation_type.__name__}]\n")
             self.stagnation_type.write_config(f, self.stagnation_config)
 
-            f.write(f'\n[{self.reproduction_type.__name__}]\n')
+            f.write(f"\n[{self.reproduction_type.__name__}]\n")
             self.reproduction_type.write_config(f, self.reproduction_config)

--- a/src/neat3p/distributed.py
+++ b/src/neat3p/distributed.py
@@ -90,6 +90,7 @@ class ModeError(RuntimeError):
     called without being in the mode - either a primary-specific method
     called by a secondary node or a secondary-specific method called by a primary node.
     """
+
     pass
 
 
@@ -98,18 +99,21 @@ def host_is_local(hostname, port=22):  # no port specified, just use the ssh por
     Returns True if the hostname points to the localhost, otherwise False.
     """
     hostname = socket.getfqdn(hostname)
-    if hostname in ("localhost", "0.0.0.0", "127.0.0.1", "1.0.0.127.in-addr.arpa",
-                    "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa"):
+    if hostname in (
+        "localhost",
+        "0.0.0.0",
+        "127.0.0.1",
+        "1.0.0.127.in-addr.arpa",
+        "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa",
+    ):
         return True
     localhost = socket.gethostname()
     if hostname == localhost:
         return True
     localaddrs = socket.getaddrinfo(localhost, port)
     targetaddrs = socket.getaddrinfo(hostname, port)
-    for (ignored_family, ignored_socktype, ignored_proto, ignored_canonname,
-         sockaddr) in localaddrs:
-        for (ignored_rfamily, ignored_rsocktype, ignored_rproto,
-             ignored_rcanonname, rsockaddr) in targetaddrs:
+    for ignored_family, ignored_socktype, ignored_proto, ignored_canonname, sockaddr in localaddrs:
+        for ignored_rfamily, ignored_rsocktype, ignored_rproto, ignored_rcanonname, rsockaddr in targetaddrs:
             if rsockaddr[0] == sockaddr[0]:
                 return True
     return False
@@ -162,6 +166,7 @@ def chunked(data, chunksize):
 
 class _ExtendedManager(object):
     """A class for managing the multiprocessing.managers.SyncManager"""
+
     __safe_for_unpickling__ = True  # this may not be safe for unpickling,
 
     # but this is required by pickle.
@@ -200,7 +205,8 @@ class _ExtendedManager(object):
         """Sets the value for 'secondary_state'."""
         if value not in (_STATE_RUNNING, _STATE_SHUTDOWN, _STATE_FORCED_SHUTDOWN):
             raise ValueError(
-                f"State {value!r} is invalid - needs to be one of _STATE_RUNNING, _STATE_SHUTDOWN, or _STATE_FORCED_SHUTDOWN")
+                f"State {value!r} is invalid - needs to be one of _STATE_RUNNING, _STATE_SHUTDOWN, or _STATE_FORCED_SHUTDOWN"
+            )
 
         if self.manager is None:
             raise RuntimeError("Manager not started")
@@ -225,6 +231,7 @@ class _ExtendedManager(object):
             Please see the documentation of `multiprocessing` for more
             information.
             """
+
             pass
 
         inqueue = queue.Queue()
@@ -313,14 +320,14 @@ class DistributedEvaluator(object):
     """An evaluator working across multiple machines"""
 
     def __init__(
-            self,
-            addr,
-            authkey,
-            eval_function,
-            secondary_chunksize=1,
-            num_workers=None,
-            worker_timeout=60,
-            mode=MODE_AUTO,
+        self,
+        addr,
+        authkey,
+        eval_function,
+        secondary_chunksize=1,
+        num_workers=None,
+        worker_timeout=60,
+        mode=MODE_AUTO,
     ):
         """
         ``addr`` should be a tuple of (hostname, port) pointing to the machine
@@ -355,8 +362,7 @@ class DistributedEvaluator(object):
             try:
                 self.num_workers = max(1, multiprocessing.cpu_count())
             except (RuntimeError, AttributeError):  # pragma: no cover
-                print("multiprocessing.cpu_count() gave an error; assuming 1",
-                      file=sys.stderr)
+                print("multiprocessing.cpu_count() gave an error; assuming 1", file=sys.stderr)
                 self.num_workers = 1
         self.worker_timeout = worker_timeout
         self.mode = _determine_mode(self.addr, mode)
@@ -501,10 +507,11 @@ class DistributedEvaluator(object):
                 except (socket.error, EOFError, IOError, OSError, socket.gaierror, TypeError):
                     break
                 except (managers.RemoteError, multiprocessing.ProcessError) as e:
-                    if ('Empty' in repr(e)) or ('TimeoutError' in repr(e)):
+                    if ("Empty" in repr(e)) or ("TimeoutError" in repr(e)):
                         continue
-                    if (('EOFError' in repr(e)) or ('PipeError' in repr(e)) or
-                            ('AuthenticationError' in repr(e))):  # Second for Python 3.X, Third for 3.6+
+                    if (
+                        ("EOFError" in repr(e)) or ("PipeError" in repr(e)) or ("AuthenticationError" in repr(e))
+                    ):  # Second for Python 3.X, Third for 3.6+
                         break
                     raise
                 if pool is None:
@@ -517,24 +524,19 @@ class DistributedEvaluator(object):
                     jobs = []
                     for genome_id, genome, config in tasks:
                         genome_ids.append(genome_id)
-                        jobs.append(
-                            pool.apply_async(
-                                self.eval_function, (genome, config)
-                            )
-                        )
-                    results = [
-                        job.get(timeout=self.worker_timeout) for job in jobs
-                    ]
+                        jobs.append(pool.apply_async(self.eval_function, (genome, config)))
+                    results = [job.get(timeout=self.worker_timeout) for job in jobs]
                     res = zip(genome_ids, results)
                 try:
                     self.outqueue.put(res)
                 except (socket.error, EOFError, IOError, OSError, socket.gaierror, TypeError):
                     break
                 except (managers.RemoteError, multiprocessing.ProcessError) as e:
-                    if ('Empty' in repr(e)) or ('TimeoutError' in repr(e)):
+                    if ("Empty" in repr(e)) or ("TimeoutError" in repr(e)):
                         continue
-                    if (('EOFError' in repr(e)) or ('PipeError' in repr(e)) or
-                            ('AuthenticationError' in repr(e))):  # Second for Python 3.X, Third for 3.6+
+                    if (
+                        ("EOFError" in repr(e)) or ("PipeError" in repr(e)) or ("AuthenticationError" in repr(e))
+                    ):  # Second for Python 3.X, Third for 3.6+
                         break
                     raise
 

--- a/src/neat3p/genes.py
+++ b/src/neat3p/genes.py
@@ -1,9 +1,9 @@
 """Handles node and connection genes."""
+
 import warnings
 from random import random
 
-from .attributes import FloatAttribute, BoolAttribute, StringAttribute
-
+from .attributes import BoolAttribute, FloatAttribute, StringAttribute
 
 # TODO: There is probably a lot of room for simplification of these classes using metaprogramming.
 # TODO: Evaluate using __slots__ for performance/memory usage improvement.
@@ -19,9 +19,9 @@ class BaseGene(object):
         self.key = key
 
     def __str__(self):
-        attrib = ['key'] + [a.name for a in self._gene_attributes]
-        attrib = [f'{a}={getattr(self, a)}' for a in attrib]
-        return f'{self.__class__.__name__}({", ".join(attrib)})'
+        attrib = ["key"] + [a.name for a in self._gene_attributes]
+        attrib = [f"{a}={getattr(self, a)}" for a in attrib]
+        return f"{self.__class__.__name__}({', '.join(attrib)})"
 
     def __lt__(self, other):
         assert isinstance(self.key, type(other.key)), f"Cannot compare keys {self.key!r} and {other.key!r}"
@@ -34,11 +34,12 @@ class BaseGene(object):
     @classmethod
     def get_config_params(cls):
         params = []
-        if not hasattr(cls, '_gene_attributes'):
-            setattr(cls, '_gene_attributes', getattr(cls, '__gene_attributes__'))
+        if not hasattr(cls, "_gene_attributes"):
+            setattr(cls, "_gene_attributes", getattr(cls, "__gene_attributes__"))
             warnings.warn(
                 f"Class '{cls.__name__!s}' {cls!r} needs '_gene_attributes' not '__gene_attributes__'",
-                DeprecationWarning)
+                DeprecationWarning,
+            )
         for a in cls._gene_attributes:
             params += a.get_config_params()
         return params
@@ -65,7 +66,7 @@ class BaseGene(object):
         return new_gene
 
     def crossover(self, gene2):
-        """ Creates a new gene randomly inheriting attributes from its parents."""
+        """Creates a new gene randomly inheriting attributes from its parents."""
         assert self.key == gene2.key
 
         # Note: we use "a if random() > 0.5 else b" instead of choice((a, b))
@@ -84,10 +85,12 @@ class BaseGene(object):
 
 
 class DefaultNodeGene(BaseGene):
-    _gene_attributes = [FloatAttribute('bias'),
-                        FloatAttribute('response'),
-                        StringAttribute('activation', options=''),
-                        StringAttribute('aggregation', options='')]
+    _gene_attributes = [
+        FloatAttribute("bias"),
+        FloatAttribute("response"),
+        StringAttribute("activation", options=""),
+        StringAttribute("aggregation", options=""),
+    ]
 
     def __init__(self, key):
         assert isinstance(key, int), f"DefaultNodeGene key must be an int, not {key!r}"
@@ -109,8 +112,7 @@ class DefaultNodeGene(BaseGene):
 # `product` aggregation function is rather more important than one giving
 # an output of 1 from the connection, for instance!)
 class DefaultConnectionGene(BaseGene):
-    _gene_attributes = [FloatAttribute('weight'),
-                        BoolAttribute('enabled')]
+    _gene_attributes = [FloatAttribute("weight"), BoolAttribute("enabled")]
 
     def __init__(self, key):
         assert isinstance(key, tuple), f"DefaultConnectionGene key must be a tuple, not {key!r}"

--- a/src/neat3p/genome.py
+++ b/src/neat3p/genome.py
@@ -1,4 +1,5 @@
 """Handles genomes (individuals in the population)."""
+
 import copy
 import sys
 from itertools import count
@@ -8,15 +9,24 @@ from .activations import ActivationFunctionSet
 from .aggregations import AggregationFunctionSet
 from .config import ConfigParameter, write_pretty_params
 from .genes import DefaultConnectionGene, DefaultNodeGene
-from .graphs import creates_cycle
-from .graphs import required_for_output
+from .graphs import creates_cycle, required_for_output
 
 
 class DefaultGenomeConfig(object):
     """Sets up and holds configuration information for the DefaultGenome class."""
-    allowed_connectivity = ['unconnected', 'fs_neat_nohidden', 'fs_neat', 'fs_neat_hidden',
-                            'full_nodirect', 'full', 'full_direct',
-                            'partial_nodirect', 'partial', 'partial_direct']
+
+    allowed_connectivity = [
+        "unconnected",
+        "fs_neat_nohidden",
+        "fs_neat",
+        "fs_neat_hidden",
+        "full_nodirect",
+        "full",
+        "full_direct",
+        "partial_nodirect",
+        "partial",
+        "partial_direct",
+    ]
 
     def __init__(self, params):
         # Create full set of available activation functions.
@@ -25,24 +35,26 @@ class DefaultGenomeConfig(object):
         self.aggregation_function_defs = AggregationFunctionSet()
         self.aggregation_defs = self.aggregation_function_defs
 
-        self._params = [ConfigParameter('num_inputs', int),
-                        ConfigParameter('num_outputs', int),
-                        ConfigParameter('num_hidden', int),
-                        ConfigParameter('feed_forward', bool),
-                        ConfigParameter('compatibility_disjoint_coefficient', float),
-                        ConfigParameter('compatibility_weight_coefficient', float),
-                        ConfigParameter('conn_add_prob', float),
-                        ConfigParameter('conn_delete_prob', float),
-                        ConfigParameter('node_add_prob', float),
-                        ConfigParameter('node_delete_prob', float),
-                        ConfigParameter('single_structural_mutation', bool, 'false'),
-                        ConfigParameter('structural_mutation_surer', str, 'default'),
-                        ConfigParameter('initial_connection', str, 'unconnected')]
+        self._params = [
+            ConfigParameter("num_inputs", int),
+            ConfigParameter("num_outputs", int),
+            ConfigParameter("num_hidden", int),
+            ConfigParameter("feed_forward", bool),
+            ConfigParameter("compatibility_disjoint_coefficient", float),
+            ConfigParameter("compatibility_weight_coefficient", float),
+            ConfigParameter("conn_add_prob", float),
+            ConfigParameter("conn_delete_prob", float),
+            ConfigParameter("node_add_prob", float),
+            ConfigParameter("node_delete_prob", float),
+            ConfigParameter("single_structural_mutation", bool, "false"),
+            ConfigParameter("structural_mutation_surer", str, "default"),
+            ConfigParameter("initial_connection", str, "unconnected"),
+        ]
 
         # Gather configuration data from the gene classes.
-        self.node_gene_type = params['node_gene_type']
+        self.node_gene_type = params["node_gene_type"]
         self._params += self.node_gene_type.get_config_params()
-        self.connection_gene_type = params['connection_gene_type']
+        self.connection_gene_type = params["connection_gene_type"]
         self._params += self.connection_gene_type.get_config_params()
 
         # Use the configuration data to interpret the supplied parameters.
@@ -61,24 +73,23 @@ class DefaultGenomeConfig(object):
 
         # Verify that initial connection type is valid.
         # pylint: disable=access-member-before-definition
-        if 'partial' in self.initial_connection:
+        if "partial" in self.initial_connection:
             c, p = self.initial_connection.split()
             self.initial_connection = c
             self.connection_fraction = float(p)
             if not (0 <= self.connection_fraction <= 1):
-                raise RuntimeError(
-                    "'partial' connection value must be between 0.0 and 1.0, inclusive.")
+                raise RuntimeError("'partial' connection value must be between 0.0 and 1.0, inclusive.")
 
         assert self.initial_connection in self.allowed_connectivity
 
         # Verify structural_mutation_surer is valid.
         # pylint: disable=access-member-before-definition
-        if self.structural_mutation_surer.lower() in ['1', 'yes', 'true', 'on']:
-            self.structural_mutation_surer = 'true'
-        elif self.structural_mutation_surer.lower() in ['0', 'no', 'false', 'off']:
-            self.structural_mutation_surer = 'false'
-        elif self.structural_mutation_surer.lower() == 'default':
-            self.structural_mutation_surer = 'default'
+        if self.structural_mutation_surer.lower() in ["1", "yes", "true", "on"]:
+            self.structural_mutation_surer = "true"
+        elif self.structural_mutation_surer.lower() in ["0", "no", "false", "off"]:
+            self.structural_mutation_surer = "false"
+        elif self.structural_mutation_surer.lower() == "default":
+            self.structural_mutation_surer = "default"
         else:
             error_string = f"Invalid structural_mutation_surer {self.structural_mutation_surer!r}"
             raise RuntimeError(error_string)
@@ -92,18 +103,16 @@ class DefaultGenomeConfig(object):
         self.aggregation_function_defs.add(name, func)
 
     def save(self, f):
-        if 'partial' in self.initial_connection:
+        if "partial" in self.initial_connection:
             if not (0 <= self.connection_fraction <= 1):
-                raise RuntimeError(
-                    "'partial' connection value must be between 0.0 and 1.0, inclusive.")
-            f.write(f'initial_connection      = {self.initial_connection} {self.connection_fraction}\n')
+                raise RuntimeError("'partial' connection value must be between 0.0 and 1.0, inclusive.")
+            f.write(f"initial_connection      = {self.initial_connection} {self.connection_fraction}\n")
         else:
-            f.write(f'initial_connection      = {self.initial_connection}\n')
+            f.write(f"initial_connection      = {self.initial_connection}\n")
 
         assert self.initial_connection in self.allowed_connectivity
 
-        write_pretty_params(f, self, [p for p in self._params
-                                      if 'initial_connection' not in p.name])
+        write_pretty_params(f, self, [p for p in self._params if "initial_connection" not in p.name])
 
     def get_new_node_key(self, node_dict):
         if self.node_indexer is None:
@@ -119,11 +128,11 @@ class DefaultGenomeConfig(object):
         return new_id
 
     def check_structural_mutation_surer(self):
-        if self.structural_mutation_surer == 'true':
+        if self.structural_mutation_surer == "true":
             return True
-        elif self.structural_mutation_surer == 'false':
+        elif self.structural_mutation_surer == "false":
             return False
-        elif self.structural_mutation_surer == 'default':
+        elif self.structural_mutation_surer == "default":
             return self.single_structural_mutation
         else:
             error_string = f"Invalid structural_mutation_surer {self.structural_mutation_surer!r}"
@@ -154,8 +163,8 @@ class DefaultGenome(object):
 
     @classmethod
     def parse_config(cls, param_dict):
-        param_dict['node_gene_type'] = DefaultNodeGene
-        param_dict['connection_gene_type'] = DefaultConnectionGene
+        param_dict["node_gene_type"] = DefaultNodeGene
+        param_dict["connection_gene_type"] = DefaultConnectionGene
         return DefaultGenomeConfig(param_dict)
 
     @classmethod
@@ -190,10 +199,10 @@ class DefaultGenome(object):
 
         # Add connections based on initial connectivity type.
 
-        if 'fs_neat' in config.initial_connection:
-            if config.initial_connection == 'fs_neat_nohidden':
+        if "fs_neat" in config.initial_connection:
+            if config.initial_connection == "fs_neat_nohidden":
                 self.connect_fs_neat_nohidden(config)
-            elif config.initial_connection == 'fs_neat_hidden':
+            elif config.initial_connection == "fs_neat_hidden":
                 self.connect_fs_neat_hidden(config)
             else:
                 if config.num_hidden > 0:
@@ -201,12 +210,14 @@ class DefaultGenome(object):
                         "Warning: initial_connection = fs_neat will not connect to hidden nodes;",
                         "\tif this is desired, set initial_connection = fs_neat_nohidden;",
                         "\tif not, set initial_connection = fs_neat_hidden",
-                        sep='\n', file=sys.stderr)
+                        sep="\n",
+                        file=sys.stderr,
+                    )
                 self.connect_fs_neat_nohidden(config)
-        elif 'full' in config.initial_connection:
-            if config.initial_connection == 'full_nodirect':
+        elif "full" in config.initial_connection:
+            if config.initial_connection == "full_nodirect":
                 self.connect_full_nodirect(config)
-            elif config.initial_connection == 'full_direct':
+            elif config.initial_connection == "full_direct":
                 self.connect_full_direct(config)
             else:
                 if config.num_hidden > 0:
@@ -214,12 +225,14 @@ class DefaultGenome(object):
                         "Warning: initial_connection = full with hidden nodes will not do direct input-output connections;",
                         "\tif this is desired, set initial_connection = full_nodirect;",
                         "\tif not, set initial_connection = full_direct",
-                        sep='\n', file=sys.stderr)
+                        sep="\n",
+                        file=sys.stderr,
+                    )
                 self.connect_full_nodirect(config)
-        elif 'partial' in config.initial_connection:
-            if config.initial_connection == 'partial_nodirect':
+        elif "partial" in config.initial_connection:
+            if config.initial_connection == "partial_nodirect":
                 self.connect_partial_nodirect(config)
-            elif config.initial_connection == 'partial_direct':
+            elif config.initial_connection == "partial_direct":
                 self.connect_partial_direct(config)
             else:
                 if config.num_hidden > 0:
@@ -227,11 +240,13 @@ class DefaultGenome(object):
                         "Warning: initial_connection = partial with hidden nodes will not do direct input-output connections;",
                         f"\tif this is desired, set initial_connection = partial_nodirect {config.connection_fraction};",
                         f"\tif not, set initial_connection = partial_direct {config.connection_fraction}",
-                        sep='\n', file=sys.stderr)
+                        sep="\n",
+                        file=sys.stderr,
+                    )
                 self.connect_partial_nodirect(config)
 
     def configure_crossover(self, genome1, genome2, config):
-        """ Configure a new genome by crossover from two parent genomes. """
+        """Configure a new genome by crossover from two parent genomes."""
         if genome1.fitness > genome2.fitness:
             parent1, parent2 = genome1, genome2
         else:
@@ -262,21 +277,22 @@ class DefaultGenome(object):
                 self.nodes[key] = ng1.crossover(ng2)
 
     def mutate(self, config):
-        """ Mutates this genome. """
+        """Mutates this genome."""
 
         if config.single_structural_mutation:
-            div = max(1, (config.node_add_prob + config.node_delete_prob +
-                          config.conn_add_prob + config.conn_delete_prob))
+            div = max(
+                1, (config.node_add_prob + config.node_delete_prob + config.conn_add_prob + config.conn_delete_prob)
+            )
             r = random()
             if r < (config.node_add_prob / div):
                 self.mutate_add_node(config)
             elif r < ((config.node_add_prob + config.node_delete_prob) / div):
                 self.mutate_delete_node(config)
-            elif r < ((config.node_add_prob + config.node_delete_prob +
-                       config.conn_add_prob) / div):
+            elif r < ((config.node_add_prob + config.node_delete_prob + config.conn_add_prob) / div):
                 self.mutate_add_connection(config)
-            elif r < ((config.node_add_prob + config.node_delete_prob +
-                       config.conn_add_prob + config.conn_delete_prob) / div):
+            elif r < (
+                (config.node_add_prob + config.node_delete_prob + config.conn_add_prob + config.conn_delete_prob) / div
+            ):
                 self.mutate_delete_connection()
         else:
             if random() < config.node_add_prob:
@@ -414,9 +430,7 @@ class DefaultGenome(object):
                     node_distance += n1.distance(n2, config)
 
             max_nodes = max(len(self.nodes), len(other.nodes))
-            node_distance = (node_distance +
-                             (config.compatibility_disjoint_coefficient *
-                              disjoint_nodes)) / max_nodes
+            node_distance = (node_distance + (config.compatibility_disjoint_coefficient * disjoint_nodes)) / max_nodes
 
         # Compute connection gene differences.
         connection_distance = 0.0
@@ -435,9 +449,9 @@ class DefaultGenome(object):
                     connection_distance += c1.distance(c2, config)
 
             max_conn = max(len(self.connections), len(other.connections))
-            connection_distance = (connection_distance +
-                                   (config.compatibility_disjoint_coefficient *
-                                    disjoint_connections)) / max_conn
+            connection_distance = (
+                connection_distance + (config.compatibility_disjoint_coefficient * disjoint_connections)
+            ) / max_conn
 
         distance = node_distance + connection_distance
         return distance
@@ -535,7 +549,7 @@ class DefaultGenome(object):
             self.connections[connection.key] = connection
 
     def connect_full_direct(self, config):
-        """ Create a fully-connected genome, including direct input-output connections. """
+        """Create a fully-connected genome, including direct input-output connections."""
         for input_id, output_id in self.compute_full_connections(config, True):
             connection = self.create_connection(config, input_id, output_id)
             self.connections[connection.key] = connection
@@ -567,8 +581,9 @@ class DefaultGenome(object):
             self.connections[connection.key] = connection
 
     def get_pruned_copy(self, genome_config):
-        used_node_genes, used_connection_genes = get_pruned_genes(self.nodes, self.connections,
-                                                                  genome_config.input_keys, genome_config.output_keys)
+        used_node_genes, used_connection_genes = get_pruned_genes(
+            self.nodes, self.connections, genome_config.input_keys, genome_config.output_keys
+        )
         new_genome = DefaultGenome(None)
         new_genome.nodes = used_node_genes
         new_genome.connections = used_connection_genes

--- a/src/neat3p/math_util.py
+++ b/src/neat3p/math_util.py
@@ -1,6 +1,6 @@
 """Commonly used functions not available in the Python2 standard library."""
 
-from math import sqrt, exp
+from math import exp, sqrt
 
 
 def mean(values):
@@ -47,5 +47,4 @@ def softmax(values):
 
 
 # Lookup table for commonly used {value} -> value functions.
-stat_functions = {'min': min, 'max': max, 'mean': mean, 'median': median,
-                  'median2': median2}
+stat_functions = {"min": min, "max": max, "mean": mean, "median": median, "median2": median2}

--- a/src/neat3p/parallel.py
+++ b/src/neat3p/parallel.py
@@ -2,6 +2,7 @@
 Runs evaluation functions in parallel subprocesses
 in order to evaluate multiple genomes at once.
 """
+
 from multiprocessing import Pool
 
 

--- a/src/neat3p/population.py
+++ b/src/neat3p/population.py
@@ -22,24 +22,19 @@ class Population(object):
         self.reporters = ReporterSet()
         self.config = config
         stagnation = config.stagnation_type(config.stagnation_config, self.reporters)
-        self.reproduction = config.reproduction_type(config.reproduction_config,
-                                                     self.reporters,
-                                                     stagnation)
-        if config.fitness_criterion == 'max':
+        self.reproduction = config.reproduction_type(config.reproduction_config, self.reporters, stagnation)
+        if config.fitness_criterion == "max":
             self.fitness_criterion = max
-        elif config.fitness_criterion == 'min':
+        elif config.fitness_criterion == "min":
             self.fitness_criterion = min
-        elif config.fitness_criterion == 'mean':
+        elif config.fitness_criterion == "mean":
             self.fitness_criterion = mean
         elif not config.no_fitness_termination:
-            raise RuntimeError(
-                "Unexpected fitness_criterion: {0!r}".format(config.fitness_criterion))
+            raise RuntimeError("Unexpected fitness_criterion: {0!r}".format(config.fitness_criterion))
 
         if initial_state is None:
             # Create a population from scratch, then partition into species.
-            self.population = self.reproduction.create_new(config.genome_type,
-                                                           config.genome_config,
-                                                           config.pop_size)
+            self.population = self.reproduction.create_new(config.genome_type, config.genome_config, config.pop_size)
             self.species = config.species_set_type(config.species_set_config, self.reporters)
             self.generation = 0
             self.species.speciate(config, self.population, self.generation)
@@ -108,8 +103,9 @@ class Population(object):
                     break
 
             # Create the next generation from the current generation.
-            self.population = self.reproduction.reproduce(self.config, self.species,
-                                                          self.config.pop_size, self.generation)
+            self.population = self.reproduction.reproduce(
+                self.config, self.species, self.config.pop_size, self.generation
+            )
 
             # Check for complete extinction.
             if not self.species.species:
@@ -118,9 +114,9 @@ class Population(object):
                 # If requested by the user, create a completely new population,
                 # otherwise raise an exception.
                 if self.config.reset_on_extinction:
-                    self.population = self.reproduction.create_new(self.config.genome_type,
-                                                                   self.config.genome_config,
-                                                                   self.config.pop_size)
+                    self.population = self.reproduction.create_new(
+                        self.config.genome_type, self.config.genome_config, self.config.pop_size
+                    )
                 else:
                     raise CompleteExtinctionException()
 

--- a/src/neat3p/reporting.py
+++ b/src/neat3p/reporting.py
@@ -96,14 +96,14 @@ class StdOutReporter(BaseReporter):
 
     def start_generation(self, generation):
         self.generation = generation
-        print('\n ****** Running generation {0} ****** \n'.format(generation))
+        print("\n ****** Running generation {0} ****** \n".format(generation))
         self.generation_start_time = time.time()
 
     def end_generation(self, config, population, species_set):
         ng = len(population)
         ns = len(species_set.species)
         if self.show_species_detail:
-            print('Population of {0:d} members in {1:d} species:'.format(ng, ns))
+            print("Population of {0:d} members in {1:d} species:".format(ng, ns))
             print("   ID   age  size   fitness   adj fit  stag")
             print("  ====  ===  ====  =========  =======  ====")
             for sid in sorted(species_set.species):
@@ -115,13 +115,13 @@ class StdOutReporter(BaseReporter):
                 st = self.generation - s.last_improved
                 print(f"  {sid:>4}  {a:>3}  {n:>4}  {f:>9}  {af:>7}  {st:>4}")
         else:
-            print('Population of {0:d} members in {1:d} species'.format(ng, ns))
+            print("Population of {0:d} members in {1:d} species".format(ng, ns))
 
         elapsed = time.time() - self.generation_start_time
         self.generation_times.append(elapsed)
         self.generation_times = self.generation_times[-10:]
         average = sum(self.generation_times) / len(self.generation_times)
-        print('Total extinctions: {0:d}'.format(self.num_extinctions))
+        print("Total extinctions: {0:d}".format(self.num_extinctions))
         if len(self.generation_times) > 1:
             print("Generation time: {0:.3f} sec ({1:.3f} average)".format(elapsed, average))
         else:
@@ -133,20 +133,23 @@ class StdOutReporter(BaseReporter):
         fit_mean = mean(fitnesses)
         fit_std = stdev(fitnesses)
         best_species_id = species.get_species_id(best_genome.key)
-        print('Population\'s average fitness: {0:3.5f} stdev: {1:3.5f}'.format(fit_mean, fit_std))
+        print("Population's average fitness: {0:3.5f} stdev: {1:3.5f}".format(fit_mean, fit_std))
         print(
-            'Best fitness: {0:3.5f} - size: {1!r} - species {2} - id {3}'.format(best_genome.fitness,
-                                                                                 best_genome.size(),
-                                                                                 best_species_id,
-                                                                                 best_genome.key))
+            "Best fitness: {0:3.5f} - size: {1!r} - species {2} - id {3}".format(
+                best_genome.fitness, best_genome.size(), best_species_id, best_genome.key
+            )
+        )
 
     def complete_extinction(self):
         self.num_extinctions += 1
-        print('All species extinct.')
+        print("All species extinct.")
 
     def found_solution(self, config, generation, best):
-        print('\nBest individual in generation {0} meets fitness threshold - complexity: {1!r}'.format(
-            self.generation, best.size()))
+        print(
+            "\nBest individual in generation {0} meets fitness threshold - complexity: {1!r}".format(
+                self.generation, best.size()
+            )
+        )
 
     def species_stagnant(self, sid, species):
         if self.show_species_detail:

--- a/src/neat3p/reproduction.py
+++ b/src/neat3p/reproduction.py
@@ -10,7 +10,6 @@ from itertools import count
 from .config import ConfigParameter, DefaultClassConfig
 from .math_util import mean
 
-
 # TODO: Provide some sort of optional cross-species performance criteria, which
 # are then used to control stagnation and possibly the mutation rate
 # configuration. This scheme should be adaptive so that species do not evolve
@@ -25,10 +24,14 @@ class DefaultReproduction(DefaultClassConfig):
 
     @classmethod
     def parse_config(cls, param_dict):
-        return DefaultClassConfig(param_dict,
-                                  [ConfigParameter('elitism', int, 0),
-                                   ConfigParameter('survival_threshold', float, 0.2),
-                                   ConfigParameter('min_species_size', int, 1)])
+        return DefaultClassConfig(
+            param_dict,
+            [
+                ConfigParameter("elitism", int, 0),
+                ConfigParameter("survival_threshold", float, 0.2),
+                ConfigParameter("min_species_size", int, 1),
+            ],
+        )
 
     def __init__(self, config, reporters, stagnation):
         # pylint: disable=super-init-not-called
@@ -134,8 +137,7 @@ class DefaultReproduction(DefaultClassConfig):
         # self.reproduction_config.elitism)? That would probably produce more accurate tracking
         # of population sizes and relative fitnesses... doing. TODO: document.
         min_species_size = max(min_species_size, self.reproduction_config.elitism)
-        spawn_amounts = self.compute_spawn(adjusted_fitnesses, previous_sizes,
-                                           pop_size, min_species_size)
+        spawn_amounts = self.compute_spawn(adjusted_fitnesses, previous_sizes, pop_size, min_species_size)
 
         new_population = {}
         species.species = {}
@@ -155,7 +157,7 @@ class DefaultReproduction(DefaultClassConfig):
 
             # Transfer elites to new generation.
             if self.reproduction_config.elitism > 0:
-                for i, m in old_members[:self.reproduction_config.elitism]:
+                for i, m in old_members[: self.reproduction_config.elitism]:
                     new_population[i] = m
                     spawn -= 1
 
@@ -163,8 +165,7 @@ class DefaultReproduction(DefaultClassConfig):
                 continue
 
             # Only use the survival threshold fraction to use as parents for the next generation.
-            repro_cutoff = int(math.ceil(self.reproduction_config.survival_threshold *
-                                         len(old_members)))
+            repro_cutoff = int(math.ceil(self.reproduction_config.survival_threshold * len(old_members)))
             # Use at least two parents no matter what the threshold fraction result is.
             repro_cutoff = max(repro_cutoff, 2)
             old_members = old_members[:repro_cutoff]

--- a/src/neat3p/species.py
+++ b/src/neat3p/species.py
@@ -1,4 +1,5 @@
 """Divides the population into species based on genomic distances."""
+
 from itertools import count
 
 from .config import ConfigParameter, DefaultClassConfig
@@ -48,7 +49,7 @@ class GenomeDistanceCache(object):
 
 
 class DefaultSpeciesSet(DefaultClassConfig):
-    """ Encapsulates the default speciation scheme. """
+    """Encapsulates the default speciation scheme."""
 
     def __init__(self, config, reporters):
         # pylint: disable=super-init-not-called
@@ -60,8 +61,7 @@ class DefaultSpeciesSet(DefaultClassConfig):
 
     @classmethod
     def parse_config(cls, param_dict):
-        return DefaultClassConfig(param_dict,
-                                  [ConfigParameter('compatibility_threshold', float)])
+        return DefaultClassConfig(param_dict, [ConfigParameter("compatibility_threshold", float)])
 
     def speciate(self, config, population, generation):
         """
@@ -138,8 +138,7 @@ class DefaultSpeciesSet(DefaultClassConfig):
         if len(population) > 1:
             gdmean = mean(distances.distances.values())
             gdstdev = stdev(distances.distances.values())
-            self.reporters.info(
-                'Mean genetic distance {0:.3f}, standard deviation {1:.3f}'.format(gdmean, gdstdev))
+            self.reporters.info("Mean genetic distance {0:.3f}, standard deviation {1:.3f}".format(gdmean, gdstdev))
 
     def get_species_id(self, individual_id):
         return self.genome_to_species[individual_id]

--- a/src/neat3p/stagnation.py
+++ b/src/neat3p/stagnation.py
@@ -1,9 +1,9 @@
 """Keeps track of whether species are making progress and helps remove those which are not."""
+
 import sys
 
 from .config import ConfigParameter, DefaultClassConfig
 from .math_util import stat_functions
-
 
 # TODO: Add a method for the user to change the "is stagnant" computation.
 
@@ -13,10 +13,14 @@ class DefaultStagnation(DefaultClassConfig):
 
     @classmethod
     def parse_config(cls, param_dict):
-        return DefaultClassConfig(param_dict,
-                                  [ConfigParameter('species_fitness_func', str, 'mean'),
-                                   ConfigParameter('max_stagnation', int, 15),
-                                   ConfigParameter('species_elitism', int, 0)])
+        return DefaultClassConfig(
+            param_dict,
+            [
+                ConfigParameter("species_fitness_func", str, "mean"),
+                ConfigParameter("max_stagnation", int, 15),
+                ConfigParameter("species_elitism", int, 0),
+            ],
+        )
 
     def __init__(self, config, reporters):
         # pylint: disable=super-init-not-called
@@ -24,8 +28,7 @@ class DefaultStagnation(DefaultClassConfig):
 
         self.species_fitness_func = stat_functions.get(config.species_fitness_func)
         if self.species_fitness_func is None:
-            raise RuntimeError(
-                "Unexpected species fitness func: {0!r}".format(config.species_fitness_func))
+            raise RuntimeError("Unexpected species fitness func: {0!r}".format(config.species_fitness_func))
 
         self.reporters = reporters
 

--- a/src/neat3p/statistics.py
+++ b/src/neat3p/statistics.py
@@ -2,15 +2,16 @@
 Gathers (via the reporting interface) and provides (to callers and/or a file)
 the most-fit genomes and information on genome/species fitness and species sizes.
 """
+
 import copy
 import csv
 
-from .math_util import mean, stdev, median2
+from .math_util import mean, median2, stdev
 from .reporting import BaseReporter
-
 
 # TODO: Make a version of this reporter that doesn't continually increase memory usage.
 # (Maybe periodically write blocks of history to disk, or log stats in a database?)
+
 
 class StatisticsReporter(BaseReporter):
     """
@@ -83,11 +84,9 @@ class StatisticsReporter(BaseReporter):
         self.save_species_count()
         self.save_species_fitness()
 
-    def save_genome_fitness(self,
-                            delimiter=' ',
-                            filename='fitness_history.csv'):
-        """ Saves the population's best and average fitness. """
-        with open(filename, 'w') as f:
+    def save_genome_fitness(self, delimiter=" ", filename="fitness_history.csv"):
+        """Saves the population's best and average fitness."""
+        with open(filename, "w") as f:
             w = csv.writer(f, delimiter=delimiter)
 
             best_fitness = [c.fitness for c in self.most_fit_genomes]
@@ -96,16 +95,16 @@ class StatisticsReporter(BaseReporter):
             for best, avg in zip(best_fitness, avg_fitness):
                 w.writerow([best, avg])
 
-    def save_species_count(self, delimiter=' ', filename='speciation.csv'):
-        """ Log speciation throughout evolution. """
-        with open(filename, 'w') as f:
+    def save_species_count(self, delimiter=" ", filename="speciation.csv"):
+        """Log speciation throughout evolution."""
+        with open(filename, "w") as f:
             w = csv.writer(f, delimiter=delimiter)
             for s in self.get_species_sizes():
                 w.writerow(s)
 
-    def save_species_fitness(self, delimiter=' ', null_value='NA', filename='species_fitness.csv'):
-        """ Log species' average fitness throughout evolution. """
-        with open(filename, 'w') as f:
+    def save_species_fitness(self, delimiter=" ", null_value="NA", filename="species_fitness.csv"):
+        """Log species' average fitness throughout evolution."""
+        with open(filename, "w") as f:
             w = csv.writer(f, delimiter=delimiter)
             for s in self.get_species_fitness(null_value):
                 w.writerow(s)
@@ -123,7 +122,7 @@ class StatisticsReporter(BaseReporter):
 
         return species_counts
 
-    def get_species_fitness(self, null_value=''):
+    def get_species_fitness(self, null_value=""):
         all_species = set()
         for gen_data in self.generation_statistics:
             all_species = all_species.union(gen_data.keys())

--- a/src/neat3p/utils.py
+++ b/src/neat3p/utils.py
@@ -1,3 +1,2 @@
-
 def this_is_neat():
     return True

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -3,9 +3,9 @@ import os
 import neat3p
 from neat3p import activations
 
-
 # TODO: These are just smoke tests to make sure nothing has become badly broken.  Expand
 # to include more detailed tests of actual functionality.
+
 
 class NotAlmostEqualException(Exception):
     pass
@@ -33,8 +33,7 @@ def test_sin():
 
 def test_gauss():
     assert_almost_equal(activations.gauss_activation(0.0), 1.0)
-    assert_almost_equal(activations.gauss_activation(-1.0),
-                        activations.gauss_activation(1.0))
+    assert_almost_equal(activations.gauss_activation(-1.0), activations.gauss_activation(1.0))
 
 
 def test_relu():
@@ -107,19 +106,23 @@ def test_cube():
 
 
 def plus_activation(x):
-    """ Not useful - just a check. """
+    """Not useful - just a check."""
     return abs(x + 1)
 
 
 def test_add_plus():
     local_dir = os.path.dirname(__file__)
-    config_path = os.path.join(local_dir, 'test_configuration')
-    config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                         neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                         config_path)
-    config.genome_config.add_activation('plus', plus_activation)
-    assert config.genome_config.activation_defs.get('plus') is not None
-    assert config.genome_config.activation_defs.is_valid('plus')
+    config_path = os.path.join(local_dir, "test_configuration")
+    config = neat3p.Config(
+        neat3p.DefaultGenome,
+        neat3p.DefaultReproduction,
+        neat3p.DefaultSpeciesSet,
+        neat3p.DefaultStagnation,
+        config_path,
+    )
+    config.genome_config.add_activation("plus", plus_activation)
+    assert config.genome_config.activation_defs.get("plus") is not None
+    assert config.genome_config.activation_defs.is_valid("plus")
 
 
 def dud_function():
@@ -128,54 +131,58 @@ def dud_function():
 
 def test_function_set():
     s = activations.ActivationFunctionSet()
-    assert s.get('sigmoid') is not None
-    assert s.get('tanh') is not None
-    assert s.get('sin') is not None
-    assert s.get('gauss') is not None
-    assert s.get('relu') is not None
-    assert s.get('elu') is not None
-    assert s.get('lelu') is not None
-    assert s.get('selu') is not None
-    assert s.get('identity') is not None
-    assert s.get('clamped') is not None
-    assert s.get('inv') is not None
-    assert s.get('log') is not None
-    assert s.get('exp') is not None
-    assert s.get('abs') is not None
-    assert s.get('hat') is not None
-    assert s.get('square') is not None
-    assert s.get('cube') is not None
+    assert s.get("sigmoid") is not None
+    assert s.get("tanh") is not None
+    assert s.get("sin") is not None
+    assert s.get("gauss") is not None
+    assert s.get("relu") is not None
+    assert s.get("elu") is not None
+    assert s.get("lelu") is not None
+    assert s.get("selu") is not None
+    assert s.get("identity") is not None
+    assert s.get("clamped") is not None
+    assert s.get("inv") is not None
+    assert s.get("log") is not None
+    assert s.get("exp") is not None
+    assert s.get("abs") is not None
+    assert s.get("hat") is not None
+    assert s.get("square") is not None
+    assert s.get("cube") is not None
 
-    assert s.is_valid('sigmoid')
-    assert s.is_valid('tanh')
-    assert s.is_valid('sin')
-    assert s.is_valid('gauss')
-    assert s.is_valid('relu')
-    assert s.is_valid('elu')
-    assert s.is_valid('lelu')
-    assert s.is_valid('selu')
-    assert s.is_valid('identity')
-    assert s.is_valid('clamped')
-    assert s.is_valid('inv')
-    assert s.is_valid('log')
-    assert s.is_valid('exp')
-    assert s.is_valid('abs')
-    assert s.is_valid('hat')
-    assert s.is_valid('square')
-    assert s.is_valid('cube')
+    assert s.is_valid("sigmoid")
+    assert s.is_valid("tanh")
+    assert s.is_valid("sin")
+    assert s.is_valid("gauss")
+    assert s.is_valid("relu")
+    assert s.is_valid("elu")
+    assert s.is_valid("lelu")
+    assert s.is_valid("selu")
+    assert s.is_valid("identity")
+    assert s.is_valid("clamped")
+    assert s.is_valid("inv")
+    assert s.is_valid("log")
+    assert s.is_valid("exp")
+    assert s.is_valid("abs")
+    assert s.is_valid("hat")
+    assert s.is_valid("square")
+    assert s.is_valid("cube")
 
-    assert not s.is_valid('foo')
+    assert not s.is_valid("foo")
 
 
 def test_bad_add1():
     local_dir = os.path.dirname(__file__)
-    config_path = os.path.join(local_dir, 'test_configuration')
-    config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                         neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                         config_path)
+    config_path = os.path.join(local_dir, "test_configuration")
+    config = neat3p.Config(
+        neat3p.DefaultGenome,
+        neat3p.DefaultReproduction,
+        neat3p.DefaultSpeciesSet,
+        neat3p.DefaultStagnation,
+        config_path,
+    )
 
     try:
-        config.genome_config.add_activation('1.0', 1.0)
+        config.genome_config.add_activation("1.0", 1.0)
     except TypeError:
         pass
     else:
@@ -184,20 +191,24 @@ def test_bad_add1():
 
 def test_bad_add2():
     local_dir = os.path.dirname(__file__)
-    config_path = os.path.join(local_dir, 'test_configuration')
-    config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                         neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                         config_path)
+    config_path = os.path.join(local_dir, "test_configuration")
+    config = neat3p.Config(
+        neat3p.DefaultGenome,
+        neat3p.DefaultReproduction,
+        neat3p.DefaultSpeciesSet,
+        neat3p.DefaultStagnation,
+        config_path,
+    )
 
     try:
-        config.genome_config.add_activation('dud_function', dud_function)
+        config.genome_config.add_activation("dud_function", dud_function)
     except TypeError:
         pass
     else:
         raise Exception("Should have had a TypeError/derived for dud_function")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_sigmoid()
     test_tanh()
     test_sin()

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -3,7 +3,6 @@ import os
 import neat3p
 from neat3p import aggregations
 
-
 # TODO: These tests are just smoke tests to make sure nothing has become badly broken.  Expand
 # to include more detailed tests of actual functionality.
 
@@ -55,20 +54,24 @@ def test_mean():
 
 
 def minabs_aggregation(x):
-    """ Not particularly useful - just a check. """
+    """Not particularly useful - just a check."""
     return min(x, key=abs)
 
 
 def test_add_minabs():
     local_dir = os.path.dirname(__file__)
-    config_path = os.path.join(local_dir, 'test_configuration')
-    config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                         neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                         config_path)
-    config.genome_config.add_aggregation('minabs', minabs_aggregation)
-    assert config.genome_config.aggregation_function_defs.get('minabs') is not None
-    assert config.genome_config.aggregation_function_defs['minabs'] is not None
-    assert config.genome_config.aggregation_function_defs.is_valid('minabs')
+    config_path = os.path.join(local_dir, "test_configuration")
+    config = neat3p.Config(
+        neat3p.DefaultGenome,
+        neat3p.DefaultReproduction,
+        neat3p.DefaultSpeciesSet,
+        neat3p.DefaultStagnation,
+        config_path,
+    )
+    config.genome_config.add_aggregation("minabs", minabs_aggregation)
+    assert config.genome_config.aggregation_function_defs.get("minabs") is not None
+    assert config.genome_config.aggregation_function_defs["minabs"] is not None
+    assert config.genome_config.aggregation_function_defs.is_valid("minabs")
 
 
 def dud_function():
@@ -77,26 +80,26 @@ def dud_function():
 
 def test_function_set():
     s = aggregations.AggregationFunctionSet()
-    assert s.get('sum') is not None
-    assert s.get('product') is not None
-    assert s.get('max') is not None
-    assert s.get('min') is not None
-    assert s.get('maxabs') is not None
-    assert s.get('median') is not None
-    assert s.get('mean') is not None
+    assert s.get("sum") is not None
+    assert s.get("product") is not None
+    assert s.get("max") is not None
+    assert s.get("min") is not None
+    assert s.get("maxabs") is not None
+    assert s.get("median") is not None
+    assert s.get("mean") is not None
 
-    assert s.is_valid('sum')
-    assert s.is_valid('product')
-    assert s.is_valid('max')
-    assert s.is_valid('min')
-    assert s.is_valid('maxabs')
-    assert s.is_valid('median')
-    assert s.is_valid('mean')
+    assert s.is_valid("sum")
+    assert s.is_valid("product")
+    assert s.is_valid("max")
+    assert s.is_valid("min")
+    assert s.is_valid("maxabs")
+    assert s.is_valid("median")
+    assert s.is_valid("mean")
 
-    assert not s.is_valid('foo')
+    assert not s.is_valid("foo")
 
     try:
-        ignored = s['foo']
+        ignored = s["foo"]
     except TypeError:
         pass
     else:
@@ -105,13 +108,17 @@ def test_function_set():
 
 def test_bad_add1():
     local_dir = os.path.dirname(__file__)
-    config_path = os.path.join(local_dir, 'test_configuration')
-    config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                         neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                         config_path)
+    config_path = os.path.join(local_dir, "test_configuration")
+    config = neat3p.Config(
+        neat3p.DefaultGenome,
+        neat3p.DefaultReproduction,
+        neat3p.DefaultSpeciesSet,
+        neat3p.DefaultStagnation,
+        config_path,
+    )
 
     try:
-        config.genome_config.add_aggregation('1.0', 1.0)
+        config.genome_config.add_aggregation("1.0", 1.0)
     except TypeError:
         pass
     else:
@@ -120,20 +127,24 @@ def test_bad_add1():
 
 def test_bad_add2():
     local_dir = os.path.dirname(__file__)
-    config_path = os.path.join(local_dir, 'test_configuration')
-    config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                         neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                         config_path)
+    config_path = os.path.join(local_dir, "test_configuration")
+    config = neat3p.Config(
+        neat3p.DefaultGenome,
+        neat3p.DefaultReproduction,
+        neat3p.DefaultSpeciesSet,
+        neat3p.DefaultStagnation,
+        config_path,
+    )
 
     try:
-        config.genome_config.add_aggregation('dud_function', dud_function)
+        config.genome_config.add_aggregation("dud_function", dud_function)
     except TypeError:
         pass
     else:
         raise Exception("Should have had a TypeError/derived for dud_function")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_sum()
     test_product()
     test_max()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,82 +8,101 @@ def test_nonexistent_config():
     an Exception with appropriate message."""
     passed = False
     try:
-        c = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                        neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                        'wubba-lubba-dub-dub')
+        c = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            "wubba-lubba-dub-dub",
+        )
     except Exception as e:
-        passed = 'No such config file' in str(e)
+        passed = "No such config file" in str(e)
     assert passed
+
 
 def test_bad_config_default_activation():
     """Check that an activation function default not in the list of options
     raises an Exception with the appropriate message."""
-    test_bad_config_RuntimeError(config_file='bad_configuration0')
+    test_bad_config_RuntimeError(config_file="bad_configuration0")
+
 
 def test_bad_config_unknown_option():
     """Check that an unknown option (at least in some sections) raises an exception."""
     local_dir = os.path.dirname(__file__)
-    config_path = os.path.join(local_dir, 'bad_configuration2')
+    config_path = os.path.join(local_dir, "bad_configuration2")
     try:
-        config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                             neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                             config_path)
+        config = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path,
+        )
     except NameError:
         pass
     else:
-        raise Exception("Did not get a NameError from an unknown configuration file option (in the 'DefaultSpeciesSet' section)")
-    config3_path = os.path.join(local_dir, 'bad_configuration3')
+        raise Exception(
+            "Did not get a NameError from an unknown configuration file option (in the 'DefaultSpeciesSet' section)"
+        )
+    config3_path = os.path.join(local_dir, "bad_configuration3")
     try:
-        config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                             neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                             config3_path)
+        config = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config3_path,
+        )
     except NameError:
         pass
     else:
         raise Exception("Did not get a NameError from an unknown configuration file option (in the 'NEAT' section)")
 
 
-def test_bad_config_RuntimeError(config_file='bad_configuration4'):
+def test_bad_config_RuntimeError(config_file="bad_configuration4"):
     """Test for RuntimeError with a bad configuration file."""
     local_dir = os.path.dirname(__file__)
     config_path = os.path.join(local_dir, config_file)
     try:
-        config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                             neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                             config_path)
+        config = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path,
+        )
     except RuntimeError:
         pass
     else:
-        raise Exception(
-            "Should have had a RuntimeError with {!s}".format(config_file))
+        raise Exception("Should have had a RuntimeError with {!s}".format(config_file))
 
 
 def test_bad_config5():
     """Test using bad_configuration5 for a RuntimeError."""
-    test_bad_config_RuntimeError(config_file='bad_configuration5')
+    test_bad_config_RuntimeError(config_file="bad_configuration5")
 
 
 def test_bad_config6():
     """Test using bad_configuration6 for a RuntimeError."""
-    test_bad_config_RuntimeError(config_file='bad_configuration6')
+    test_bad_config_RuntimeError(config_file="bad_configuration6")
 
 
 def test_bad_config7():
     """Test using bad_configuration7 for a RuntimeError."""
-    test_bad_config_RuntimeError(config_file='bad_configuration7')
+    test_bad_config_RuntimeError(config_file="bad_configuration7")
 
 
 def test_bad_config8():
     """Test using bad_configuration8 for a RuntimeError."""
-    test_bad_config_RuntimeError(config_file='bad_configuration8')
+    test_bad_config_RuntimeError(config_file="bad_configuration8")
 
 
 def test_bad_config9():
     """Test using bad_configuration9 for a RuntimeError."""
-    test_bad_config_RuntimeError(config_file='bad_configuration9')
+    test_bad_config_RuntimeError(config_file="bad_configuration9")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_nonexistent_config()
     # test_bad_config_activation()
     test_bad_config_unknown_option()

--- a/tests/test_config_save_restore.py
+++ b/tests/test_config_save_restore.py
@@ -8,8 +8,8 @@ class ConfigTests(unittest.TestCase):
     def test_config_save_restore(self):
         """Check if it is possible to restore saved config"""
 
-        config_filename_initial = 'test_configuration'
-        config_filename_save = 'save_configuration'
+        config_filename_initial = "test_configuration"
+        config_filename_save = "save_configuration"
 
         # Get config path
         local_dir = os.path.dirname(__file__)
@@ -17,8 +17,13 @@ class ConfigTests(unittest.TestCase):
         config_path_save = os.path.join(local_dir, config_filename_save)
 
         # Load initial configuration from file
-        config_initial = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                                     neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation, config_path_initial)
+        config_initial = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path_initial,
+        )
 
         config1 = config_initial.genome_config
         names1 = [p.name for p in config1._params]
@@ -29,8 +34,13 @@ class ConfigTests(unittest.TestCase):
         config_initial.save(config_path_save)
 
         # Obtain configuration from saved file
-        config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                             neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation, config_path_save)
+        config = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path_save,
+        )
 
         config2 = config.genome_config
         names2 = [p.name for p in config2._params]
@@ -47,8 +57,8 @@ class ConfigTests(unittest.TestCase):
     def test_config_save_restore1(self):
         """Check if it is possible to restore saved config2"""
 
-        config_filename_initial = 'test_configuration2'
-        config_filename_save = 'save_configuration2'
+        config_filename_initial = "test_configuration2"
+        config_filename_save = "save_configuration2"
 
         # Get config path
         local_dir = os.path.dirname(__file__)
@@ -56,8 +66,13 @@ class ConfigTests(unittest.TestCase):
         config_path_save = os.path.join(local_dir, config_filename_save)
 
         # Load initial configuration from file
-        config_initial = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                                     neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation, config_path_initial)
+        config_initial = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path_initial,
+        )
 
         config1 = config_initial.genome_config
         names1 = [p.name for p in config1._params]
@@ -68,8 +83,13 @@ class ConfigTests(unittest.TestCase):
         config_initial.save(config_path_save)
 
         # Obtain configuration from saved file
-        config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                             neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation, config_path_save)
+        config = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path_save,
+        )
 
         config2 = config.genome_config
         names2 = [p.name for p in config2._params]
@@ -86,8 +106,8 @@ class ConfigTests(unittest.TestCase):
     def test_config_save_error(self):
         """Check if get error on saving bad partial configuration"""
 
-        config_filename_initial = 'test_configuration2'
-        config_filename_save = 'save_bad_configuration'
+        config_filename_initial = "test_configuration2"
+        config_filename_save = "save_bad_configuration"
 
         # Get config path
         local_dir = os.path.dirname(__file__)
@@ -95,9 +115,13 @@ class ConfigTests(unittest.TestCase):
         config_path_save = os.path.join(local_dir, config_filename_save)
 
         # Load initial configuration from file
-        config_initial = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                                     neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                                     config_path_initial)
+        config_initial = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path_initial,
+        )
 
         config_initial.genome_config.connection_fraction = 1.5
 

--- a/tests/test_genes.py
+++ b/tests/test_genes.py
@@ -1,2 +1,0 @@
-from neat3p import genes
-

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -17,20 +17,28 @@ class TestCreateNew(unittest.TestCase):
         current working directory.
         """
         local_dir = os.path.dirname(__file__)
-        config_path = os.path.join(local_dir, 'test_configuration')
-        self.config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                                  neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                                  config_path)
-        config2_path = os.path.join(local_dir, 'test_configuration2')
-        self.config2 = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                                   neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                                   config2_path)
+        config_path = os.path.join(local_dir, "test_configuration")
+        self.config = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path,
+        )
+        config2_path = os.path.join(local_dir, "test_configuration2")
+        self.config2 = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config2_path,
+        )
 
     def test_unconnected_no_hidden(self):
         """Unconnected network with only input and output nodes."""
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'unconnected'
+        config.initial_connection = "unconnected"
         config.num_hidden = 0
 
         g = neat3p.DefaultGenome(gid)
@@ -39,13 +47,13 @@ class TestCreateNew(unittest.TestCase):
 
         print(g)
         self.assertEqual(set(g.nodes), {0})
-        assert (not g.connections)
+        assert not g.connections
 
     def test_unconnected_hidden(self):
         """Unconnected network with hidden nodes."""
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'unconnected'
+        config.initial_connection = "unconnected"
         config.num_hidden = 2
 
         g = neat3p.DefaultGenome(gid)
@@ -54,7 +62,7 @@ class TestCreateNew(unittest.TestCase):
 
         print(g)
         self.assertEqual(set(g.nodes), {0, 1, 2})
-        assert (not g.connections)
+        assert not g.connections
 
     def test_fs_neat_no_hidden(self):
         """
@@ -63,7 +71,7 @@ class TestCreateNew(unittest.TestCase):
         """
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'fs_neat'
+        config.initial_connection = "fs_neat"
         config.num_hidden = 0
 
         g = neat3p.DefaultGenome(gid)
@@ -81,7 +89,7 @@ class TestCreateNew(unittest.TestCase):
         """
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'fs_neat'
+        config.initial_connection = "fs_neat"
         config.num_hidden = 2
 
         g = neat3p.DefaultGenome(gid)
@@ -97,7 +105,7 @@ class TestCreateNew(unittest.TestCase):
         """fs_neat not connecting hidden nodes."""
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'fs_neat_nohidden'
+        config.initial_connection = "fs_neat_nohidden"
         config.num_hidden = 2
 
         g = neat3p.DefaultGenome(gid)
@@ -112,7 +120,7 @@ class TestCreateNew(unittest.TestCase):
         """fs_neat with connecting hidden nodes."""
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'fs_neat_hidden'
+        config.initial_connection = "fs_neat_hidden"
         config.num_hidden = 2
 
         g = neat3p.DefaultGenome(gid)
@@ -130,7 +138,7 @@ class TestCreateNew(unittest.TestCase):
         """
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'full'
+        config.initial_connection = "full"
         config.num_hidden = 0
 
         g = neat3p.DefaultGenome(gid)
@@ -143,7 +151,7 @@ class TestCreateNew(unittest.TestCase):
 
         # Check that each input is connected to the output node
         for i in config.input_keys:
-            assert ((i, 0) in g.connections)
+            assert (i, 0) in g.connections
 
     def test_fully_connected_hidden_nodirect_old(self):
         """
@@ -152,7 +160,7 @@ class TestCreateNew(unittest.TestCase):
         """
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'full'
+        config.initial_connection = "full"
         config.num_hidden = 2
 
         g = neat3p.DefaultGenome(gid)
@@ -167,21 +175,21 @@ class TestCreateNew(unittest.TestCase):
         # Check that each input is connected to each hidden node.
         for i in config.input_keys:
             for h in (1, 2):
-                assert ((i, h) in g.connections)
+                assert (i, h) in g.connections
 
         # Check that each hidden node is connected to the output.
         for h in (1, 2):
-            assert ((h, 0) in g.connections)
+            assert (h, 0) in g.connections
 
         # Check that inputs are not directly connected to the output
         for i in config.input_keys:
-            assert ((i, 0) not in g.connections)
+            assert (i, 0) not in g.connections
 
     def test_fully_connected_hidden_nodirect(self):
         """full with no direct input-output connections, only via hidden nodes."""
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'full_nodirect'
+        config.initial_connection = "full_nodirect"
         config.num_hidden = 2
 
         g = neat3p.DefaultGenome(gid)
@@ -195,21 +203,21 @@ class TestCreateNew(unittest.TestCase):
         # Check that each input is connected to each hidden node.
         for i in config.input_keys:
             for h in (1, 2):
-                assert ((i, h) in g.connections)
+                assert (i, h) in g.connections
 
         # Check that each hidden node is connected to the output.
         for h in (1, 2):
-            assert ((h, 0) in g.connections)
+            assert (h, 0) in g.connections
 
         # Check that inputs are not directly connected to the output
         for i in config.input_keys:
-            assert ((i, 0) not in g.connections)
+            assert (i, 0) not in g.connections
 
     def test_fully_connected_hidden_direct(self):
         """full with direct input-output connections (and also via hidden hodes)."""
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'full_direct'
+        config.initial_connection = "full_direct"
         config.num_hidden = 2
 
         g = neat3p.DefaultGenome(gid)
@@ -223,15 +231,15 @@ class TestCreateNew(unittest.TestCase):
         # Check that each input is connected to each hidden node.
         for i in config.input_keys:
             for h in (1, 2):
-                assert ((i, h) in g.connections)
+                assert (i, h) in g.connections
 
         # Check that each hidden node is connected to the output.
         for h in (1, 2):
-            assert ((h, 0) in g.connections)
+            assert (h, 0) in g.connections
 
         # Check that inputs are directly connected to the output
         for i in config.input_keys:
-            assert ((i, 0) in g.connections)
+            assert (i, 0) in g.connections
 
     def test_partially_connected_no_hidden(self):
         """
@@ -240,7 +248,7 @@ class TestCreateNew(unittest.TestCase):
         """
         gid = 42
         config = self.config2.genome_config
-        config.initial_connection = 'partial'
+        config.initial_connection = "partial"
         config.connection_fraction = 0.5
         config.num_hidden = 0
 
@@ -259,7 +267,7 @@ class TestCreateNew(unittest.TestCase):
         """
         gid = 42
         config = self.config2.genome_config
-        config.initial_connection = 'partial'
+        config.initial_connection = "partial"
         config.connection_fraction = 0.5
         config.num_hidden = 2
 
@@ -276,7 +284,7 @@ class TestCreateNew(unittest.TestCase):
         """partial with no direct input-output connections, only via hidden nodes."""
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'partial_nodirect'
+        config.initial_connection = "partial_nodirect"
         config.connection_fraction = 0.5
         config.num_hidden = 2
 
@@ -295,7 +303,7 @@ class TestCreateNew(unittest.TestCase):
         """
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'partial_direct'
+        config.initial_connection = "partial_direct"
         config.connection_fraction = 0.5
         config.num_hidden = 2
 
@@ -318,15 +326,19 @@ class TestPruning(unittest.TestCase):
         current working directory.
         """
         local_dir = os.path.dirname(__file__)
-        config_path = os.path.join(local_dir, 'test_configuration')
-        self.config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                                  neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                                  config_path)
+        config_path = os.path.join(local_dir, "test_configuration")
+        self.config = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path,
+        )
 
     def test_empty_network(self):
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'unconnected'
+        config.initial_connection = "unconnected"
         config.num_hidden = 0
 
         g = neat3p.DefaultGenome(gid)
@@ -335,14 +347,14 @@ class TestPruning(unittest.TestCase):
         g_pruned = g.get_pruned_copy(config)
 
         self.assertEqual(set(g.nodes.keys()), {0})
-        assert (not g.connections)
+        assert not g.connections
         self.assertEqual(set(g.nodes.keys()), set(g_pruned.nodes.keys()))
         self.assertEqual(set(g.connections.keys()), set(g_pruned.connections.keys()))
 
     def test_nothing_to_prune(self):
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'unconnected'
+        config.initial_connection = "unconnected"
         config.num_hidden = 0
 
         g = neat3p.DefaultGenome(gid)
@@ -358,7 +370,7 @@ class TestPruning(unittest.TestCase):
     def test_unused_node(self):
         gid = 42
         config = self.config.genome_config
-        config.initial_connection = 'unconnected'
+        config.initial_connection = "unconnected"
         config.num_hidden = 0
 
         g = neat3p.DefaultGenome(gid)
@@ -381,5 +393,5 @@ class TestPruning(unittest.TestCase):
         self.assertEqual(set(g_pruned.connections.keys()), {(-1, 0), (-2, 0)})
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -1,6 +1,6 @@
 import random
 
-from neat3p.graphs import creates_cycle, required_for_output, feed_forward_layers
+from neat3p.graphs import creates_cycle, feed_forward_layers, required_for_output
 
 
 def assert_almost_equal(x, y, tol):
@@ -70,7 +70,7 @@ def test_fuzz_required():
         random.shuffle(nodes)
 
         inputs = nodes[:n_in]
-        outputs = nodes[n_in:n_in + n_out]
+        outputs = nodes[n_in : n_in + n_out]
         connections = []
         for _ in range(n_hidden * 2):
             a = random.choice(nodes)
@@ -109,20 +109,59 @@ def test_feed_forward_layers():
 
     inputs = [0, 1, 2, 3]
     outputs = [11, 12, 13]
-    connections = [(0, 4), (1, 4), (1, 5), (2, 5), (2, 6), (3, 6), (3, 7),
-                   (4, 8), (5, 8), (5, 9), (5, 10), (6, 10), (6, 7),
-                   (8, 11), (8, 12), (8, 9), (9, 10), (7, 10),
-                   (10, 12), (10, 13)]
+    connections = [
+        (0, 4),
+        (1, 4),
+        (1, 5),
+        (2, 5),
+        (2, 6),
+        (3, 6),
+        (3, 7),
+        (4, 8),
+        (5, 8),
+        (5, 9),
+        (5, 10),
+        (6, 10),
+        (6, 7),
+        (8, 11),
+        (8, 12),
+        (8, 9),
+        (9, 10),
+        (7, 10),
+        (10, 12),
+        (10, 13),
+    ]
     layers = feed_forward_layers(inputs, outputs, connections)
     assert [{4, 5, 6}, {8, 7}, {9, 11}, {10}, {12, 13}] == layers
 
     inputs = [0, 1, 2, 3]
     outputs = [11, 12, 13]
-    connections = [(0, 4), (1, 4), (1, 5), (2, 5), (2, 6), (3, 6), (3, 7),
-                   (4, 8), (5, 8), (5, 9), (5, 10), (6, 10), (6, 7),
-                   (8, 11), (8, 12), (8, 9), (9, 10), (7, 10),
-                   (10, 12), (10, 13),
-                   (3, 14), (14, 15), (5, 16), (10, 16)]
+    connections = [
+        (0, 4),
+        (1, 4),
+        (1, 5),
+        (2, 5),
+        (2, 6),
+        (3, 6),
+        (3, 7),
+        (4, 8),
+        (5, 8),
+        (5, 9),
+        (5, 10),
+        (6, 10),
+        (6, 7),
+        (8, 11),
+        (8, 12),
+        (8, 9),
+        (9, 10),
+        (7, 10),
+        (10, 12),
+        (10, 13),
+        (3, 14),
+        (14, 15),
+        (5, 16),
+        (10, 16),
+    ]
     layers = feed_forward_layers(inputs, outputs, connections)
     assert [{4, 5, 6}, {8, 7}, {9, 11}, {10}, {12, 13}] == layers
 
@@ -136,7 +175,7 @@ def test_fuzz_feed_forward_layers():
         random.shuffle(nodes)
 
         inputs = nodes[:n_in]
-        outputs = nodes[n_in:n_in + n_out]
+        outputs = nodes[n_in : n_in + n_out]
         connections = []
         for _ in range(n_hidden * 2):
             a = random.choice(nodes)
@@ -152,7 +191,7 @@ def test_fuzz_feed_forward_layers():
         feed_forward_layers(inputs, outputs, connections)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_creates_cycle()
     test_required_for_output()
     test_fuzz_required()

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1,10 +1,3 @@
-import math
-import os
-import random
-
-import neat3p
-
-
 # def test_concurrent_nn():
 #     """This is a stripped-down copy of the `memory` example."""
 #

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -6,13 +6,17 @@ import neat3p
 
 class PopulationTests(unittest.TestCase):
     def test_valid_fitness_criterion(self):
-        for c in ('max', 'min', 'mean'):
+        for c in ("max", "min", "mean"):
             # Load configuration.
             local_dir = os.path.dirname(__file__)
-            config_path = os.path.join(local_dir, 'test_configuration')
-            config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                                 neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                                 config_path)
+            config_path = os.path.join(local_dir, "test_configuration")
+            config = neat3p.Config(
+                neat3p.DefaultGenome,
+                neat3p.DefaultReproduction,
+                neat3p.DefaultSpeciesSet,
+                neat3p.DefaultStagnation,
+                config_path,
+            )
             config.fitness_criterion = c
 
             p = neat3p.Population(config)
@@ -26,11 +30,15 @@ class PopulationTests(unittest.TestCase):
     def test_invalid_fitness_criterion(self):
         # Load configuration.
         local_dir = os.path.dirname(__file__)
-        config_path = os.path.join(local_dir, 'test_configuration')
-        config = neat3p.Config(neat3p.DefaultGenome, neat3p.DefaultReproduction,
-                             neat3p.DefaultSpeciesSet, neat3p.DefaultStagnation,
-                             config_path)
-        config.fitness_criterion = 'szechaun sauce'
+        config_path = os.path.join(local_dir, "test_configuration")
+        config = neat3p.Config(
+            neat3p.DefaultGenome,
+            neat3p.DefaultReproduction,
+            neat3p.DefaultSpeciesSet,
+            neat3p.DefaultStagnation,
+            config_path,
+        )
+        config.fitness_criterion = "szechaun sauce"
 
         with self.assertRaises(Exception):
             p = neat3p.Population(config)
@@ -122,5 +130,5 @@ class PopulationTests(unittest.TestCase):
 #     # assert id(pop.statistics.generation_statistics) != id(pop2.statistics.generation_statistics)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -53,5 +53,5 @@ class TestSpawnComputation(unittest.TestCase):
         self.assertEqual(spawn, [20, 20])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 import neat3p
 
-
 # TODO: These tests are just smoke tests to make sure nothing has become badly broken.  Expand
 # to include more detailed tests of actual functionality.
+
 
 class NotAlmostEqualException(Exception):
     pass
@@ -19,10 +19,20 @@ def assert_almost_equal(a, b):
 def test_softmax():
     """Test the neat.math_utils.softmax function."""
     # Test data - below is from Wikipedia Softmax_function page.
-    test_data = [([1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0], [0.02364054302159139, 0.06426165851049616,
-                                                        0.17468129859572226, 0.47483299974438037,
-                                                        0.02364054302159139, 0.06426165851049616,
-                                                        0.17468129859572226])]
+    test_data = [
+        (
+            [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0],
+            [
+                0.02364054302159139,
+                0.06426165851049616,
+                0.17468129859572226,
+                0.47483299974438037,
+                0.02364054302159139,
+                0.06426165851049616,
+                0.17468129859572226,
+            ],
+        )
+    ]
 
     for test in test_data:
         results_list = list(neat3p.math_util.softmax(test[0]))
@@ -33,5 +43,5 @@ def test_softmax():
     # print("Softmax for [1, 2, 3, 4, 1, 2, 3] is {!r}".format(softmax_result))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_softmax()


### PR DESCRIPTION
This pull request includes several changes to the `neat3p` package, primarily focused on code formatting improvements and some minor refactoring. The most important changes include reordering imports, updating string formatting to use double quotes, and reformatting dictionary definitions.

### Code Formatting Improvements:
* [`src/neat3p/__init__.py`](diffhunk://#diff-23cedc2517cdf37b760ed3fa048b8c29c24f7eb436e630d3b7a22bbe6982ed9cL2-R21): Reordered imports to maintain consistency and readability.
* [`src/neat3p/activations.py`](diffhunk://#diff-e0dc80923f439c3caa69ac0fe649fe7bfd1e695af6a86bcbd8fa0c12d2d4b498L103-R103): Reformatted the `validate_activation` function and `ActivationFunctionSet` class to use double quotes and improve readability. [[1]](diffhunk://#diff-e0dc80923f439c3caa69ac0fe649fe7bfd1e695af6a86bcbd8fa0c12d2d4b498L103-R103) [[2]](diffhunk://#diff-e0dc80923f439c3caa69ac0fe649fe7bfd1e695af6a86bcbd8fa0c12d2d4b498L121-R135)
* [`src/neat3p/aggregations.py`](diffhunk://#diff-2b66769e31b129c7907654c50f5cc1cda71b9555e9f5923f8ad51df02a2cc699L47-R47): Updated the `validate_aggregation` function and `AggregationFunctionSet` class to use double quotes and improve readability. [[1]](diffhunk://#diff-2b66769e31b129c7907654c50f5cc1cda71b9555e9f5923f8ad51df02a2cc699L47-R47) [[2]](diffhunk://#diff-2b66769e31b129c7907654c50f5cc1cda71b9555e9f5923f8ad51df02a2cc699L62-R65)
* [`src/neat3p/attributes.py`](diffhunk://#diff-f220966cbacce21f4d7dd8a005f994fb7a793bd20fec1d4e8ff57a1d48ba474fL25-R43): Reformatted dictionary definitions and string literals to use double quotes for consistency. [[1]](diffhunk://#diff-f220966cbacce21f4d7dd8a005f994fb7a793bd20fec1d4e8ff57a1d48ba474fL25-R43) [[2]](diffhunk://#diff-f220966cbacce21f4d7dd8a005f994fb7a793bd20fec1d4e8ff57a1d48ba474fL53-R60) [[3]](diffhunk://#diff-f220966cbacce21f4d7dd8a005f994fb7a793bd20fec1d4e8ff57a1d48ba474fL93-R100) [[4]](diffhunk://#diff-f220966cbacce21f4d7dd8a005f994fb7a793bd20fec1d4e8ff57a1d48ba474fR135-R153) [[5]](diffhunk://#diff-f220966cbacce21f4d7dd8a005f994fb7a793bd20fec1d4e8ff57a1d48ba474fL172-R194) [[6]](diffhunk://#diff-f220966cbacce21f4d7dd8a005f994fb7a793bd20fec1d4e8ff57a1d48ba474fL206-R216)
* [`src/neat3p/checkpoint.py`](diffhunk://#diff-5f2e30ab82a00700f1bed32e1829fae52f7b70e3c43905debef6a0e3fb769889L18-R18): Updated string formatting in the `Checkpointer` class to use double quotes. [[1]](diffhunk://#diff-5f2e30ab82a00700f1bed32e1829fae52f7b70e3c43905debef6a0e3fb769889L18-R18) [[2]](diffhunk://#diff-5f2e30ab82a00700f1bed32e1829fae52f7b70e3c43905debef6a0e3fb769889L61-R63)
* [`src/neat3p/config.py`](diffhunk://#diff-36a15b245f9b1d95806520bb8ef626eaf847453802860bb5f148ca5c4ba41c3bL44-R44): Reformatted string literals and dictionary definitions to use double quotes for consistency and readability. [[1]](diffhunk://#diff-36a15b245f9b1d95806520bb8ef626eaf847453802860bb5f148ca5c4ba41c3bL44-R44) [[2]](diffhunk://#diff-36a15b245f9b1d95806520bb8ef626eaf847453802860bb5f148ca5c4ba41c3bL70-R71) [[3]](diffhunk://#diff-36a15b245f9b1d95806520bb8ef626eaf847453802860bb5f148ca5c4ba41c3bL88-R94) [[4]](diffhunk://#diff-36a15b245f9b1d95806520bb8ef626eaf847453802860bb5f148ca5c4ba41c3bL111-R113) [[5]](diffhunk://#diff-36a15b245f9b1d95806520bb8ef626eaf847453802860bb5f148ca5c4ba41c3bL124-R140) [[6]](diffhunk://#diff-36a15b245f9b1d95806520bb8ef626eaf847453802860bb5f148ca5c4ba41c3bL144-R176)