### PR TITLE
Create the ConfigParameter class.

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,0 +1,208 @@
+#ifndef NEAT_CONFIG_HPP
+#define NEAT_CONFIG_HPP
+
+// Include nanobind headers because we need nb::object in the constructor.
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <variant>
+#include <unordered_map>
+#include <stdexcept>
+#include <sstream>
+#include <algorithm>
+#include <cctype>
+#include <iostream>
+
+// A variant type to hold a configuration value.
+using ConfigValue = std::variant<int, bool, float, std::string, std::vector<std::string>, nb::object>;
+
+class ConfigParameter {
+public:
+    std::string name;
+    // This member holds a string (e.g. "int", "bool", "float", "list", "str") extracted from the Python type's __name__.
+    std::string value_type;
+    std::optional<ConfigValue> default_value;
+
+    // Constructor accepts a Python type object for the value type.
+    ConfigParameter(const std::string &name, const nb::object &py_type, 
+                    std::optional<ConfigValue> default_value = std::nullopt)
+        : name(name),
+          // Convert the Python type's __name__ to a std::string
+          value_type(nb::cast<std::string>(nb::getattr(py_type, "__name__"))),
+          default_value(default_value)
+    {}
+
+    // Mimics Python's __repr__.
+    std::string repr() const {
+        std::ostringstream oss;
+        oss << "ConfigParameter(" << quote(name) << ", " << quote(value_type);
+        if (!default_value.has_value()) {
+            oss << ")";
+        } else {
+            oss << ", " << configValueToString(*default_value) << ")";
+        }
+        return oss.str();
+    }
+
+    /**
+     * parse(section, config_parser)
+     *
+     * This version of parse() expects:
+     *   - section: a Python string (the INI section name)
+     *   - config_parser: a Python configparser.ConfigParser object
+     *
+     * It replicates the Python logic:
+     *
+     *   if self.value_type == int:
+     *       return config_parser.getint(section, self.name)
+     *   ...
+     */
+    ConfigValue parse(nb::object section, nb::object config_parser) const {
+        // Convert the 'section' object to a std::string
+        std::string section_str = nb::cast<std::string>(section);
+
+        try {
+            if (value_type == "int") {
+                nb::object result = config_parser.attr("getint")(section_str, name);
+                return nb::cast<int>(result);
+            } 
+            else if (value_type == "bool") {
+                nb::object result = config_parser.attr("getboolean")(section_str, name);
+                return nb::cast<bool>(result);
+            }
+            else if (value_type == "float") {
+                nb::object result = config_parser.attr("getfloat")(section_str, name);
+                return nb::cast<float>(result);
+            }
+            else if (value_type == "list") {
+                // config_parser.get(...) returns a string -> we split it
+                nb::object result = config_parser.attr("get")(section_str, name);
+                std::string s = nb::cast<std::string>(result);
+                return split(s);
+            }
+            else if (value_type == "str") {
+                nb::object result = config_parser.attr("get")(section_str, name);
+                return nb::cast<std::string>(result);
+            }
+            else {
+                throw std::runtime_error("Unexpected configuration type: " + value_type);
+            }
+        } catch (const std::exception &e) {
+            throw std::runtime_error("Error parsing config item '" + name + "': " + e.what());
+        }
+    }
+
+    // Interprets a configuration value from a nb::dict.
+    ConfigValue interpret(nb::dict config_dict) const {
+        // Check if the dictionary contains our key.
+        if (!config_dict.contains(name.c_str())) {
+            if (!default_value.has_value()) {
+                throw std::runtime_error("Missing configuration item: " + name);
+            } else {
+                std::cerr << "Warning: Using default " << configValueToString(*default_value)
+                        << " for '" << name << "'\n";
+                return *default_value;
+            }
+        }
+        // Retrieve the value as a string from the nb::dict.
+        nb::object value_obj = config_dict[name.c_str()];
+        std::string value_str = nb::cast<std::string>(value_obj);
+
+        try {
+            if (value_type == "str")
+                return value_str;
+            else if (value_type == "int")
+                return std::stoi(value_str);
+            else if (value_type == "bool") {
+                std::string lower = toLower(value_str);
+                if (lower == "true")
+                    return nb::bool_(true);
+                else if (lower == "false") {
+                    std::cout << "HERE JUST BEFORE FALSE!" << std::endl;
+                    return nb::bool_(false);
+                }
+                else
+                    throw std::runtime_error(name + " must be True or False");
+            }
+            else if (value_type == "float")
+                return std::stof(value_str);
+            else if (value_type == "list")
+                return split(value_str);
+            else
+                throw std::runtime_error("Unexpected configuration type: " + value_type);
+        } catch (const std::exception &e) {
+            throw std::runtime_error("Error interpreting config item '" + name +
+                                    "' with value '" + value_str + "': " + e.what());
+        }
+    }
+
+    // Formats a given configuration value to a string (unchanged).
+    std::string format(const ConfigValue &value) const {
+        if (value_type == "list") {
+            const auto &vec = std::get<std::vector<std::string>>(value);
+            std::ostringstream oss;
+            for (size_t i = 0; i < vec.size(); ++i) {
+                oss << vec[i];
+                if (i != vec.size() - 1)
+                    oss << " ";
+            }
+            return oss.str();
+        } else {
+            return configValueToString(value);
+        }
+    }
+
+private:
+    // Helper: converts a ConfigValue variant to a string.
+    static std::string configValueToString(const ConfigValue &val) {
+        return std::visit([](auto &&arg) -> std::string {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr(std::is_same_v<T, int>) {
+                return std::to_string(arg);
+            } else if constexpr(std::is_same_v<T, bool>) {
+                return arg ? "True" : "False";
+            } else if constexpr(std::is_same_v<T, float>) {
+                return std::to_string(arg);
+            } else if constexpr(std::is_same_v<T, std::string>) {
+                return arg;
+            } else if constexpr(std::is_same_v<T, std::vector<std::string>>) {
+                std::ostringstream oss;
+                for (size_t i = 0; i < arg.size(); ++i) {
+                    oss << arg[i];
+                    if (i != arg.size() - 1)
+                        oss << " ";
+                }
+                return oss.str();
+            } else {
+                return "";
+            }
+        }, val);
+    }
+
+    // Helper: returns a lowercase copy of a string.
+    static std::string toLower(const std::string &s) {
+        std::string lower = s;
+        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+        return lower;
+    }
+
+    // Helper: splits a string by whitespace.
+    static std::vector<std::string> split(const std::string &s) {
+        std::istringstream iss(s);
+        std::vector<std::string> tokens;
+        std::string token;
+        while (iss >> token)
+            tokens.push_back(token);
+        return tokens;
+    }
+
+    // Helper: wraps a string in quotes.
+    static std::string quote(const std::string &s) {
+        return "\"" + s + "\"";
+    }
+};
+
+#endif // NEAT_CONFIG_HPP

--- a/src/neat3p.cpp
+++ b/src/neat3p.cpp
@@ -9,76 +9,47 @@
 #include <nanobind/stl/bind_map.h>
 #include <nanobind/stl/bind_vector.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/variant.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/map.h>
 #include <spdlog/spdlog.h>
 
 #include <cstdint>
 
+#include "config.hpp"
 #include "genes.hpp"
 
 // Create a shortcut for nanobind
 namespace nb = nanobind;
 
 NB_MODULE(_neat3p, m) {
-
-    // nb::class_<GenomeParams>(m, "GenomeParams")
-    //     .def(nb::init<>())
-    //     .def_rw("num_inputs", &GenomeParams::num_inputs)
-    //     .def_rw("num_outputs", &GenomeParams::num_outputs)
-    //     .def_rw("num_hidden", &GenomeParams::num_hidden)
-    //     .def_rw("feed_forward", &GenomeParams::feed_forward)
-    //     .def_rw("compatibility_disjoint_coefficient",
-    //             &GenomeParams::compatibility_disjoint_coefficient)
-    //     .def_rw("compatibility_weight_coefficient",
-    //             &GenomeParams::compatibility_weight_coefficient)
-    //     .def_rw("conn_add_prob", &GenomeParams::conn_add_prob)
-    //     .def_rw("conn_delete_prob", &GenomeParams::conn_delete_prob)
-    //     .def_rw("node_add_prob", &GenomeParams::node_add_prob)
-    //     .def_rw("node_delete_prob", &GenomeParams::node_delete_prob)
-    //     .def_rw("single_structural_mutation", 
-    //             &GenomeParams::single_structural_mutation)
-    //     .def_rw("structural_mutation_surer", 
-    //             &GenomeParams::structural_mutation_surer)
-    //     .def_rw("initial_connection",
-    //             &GenomeParams::initial_connection);
-
-    // nb::class_<DefaultGenomeConfig>(m, "DefaultGenomeConfig")
-    //     .def(nb::init<const GenomeParams &>())
-    //     .def_rw("num_inputs", &DefaultGenomeConfig::num_inputs)
-    //     .def_rw("num_outputs", &DefaultGenomeConfig::num_outputs)
-    //     .def_rw("num_hidden", &DefaultGenomeConfig::num_hidden)
-    //     .def_rw("feed_forward", &DefaultGenomeConfig::feed_forward)
-    //     .def_rw("compatibility_disjoint_coefficient",
-    //         &DefaultGenomeConfig::compatibility_disjoint_coefficient)
-    //     .def_rw("compatibility_weight_coefficient",
-    //         &DefaultGenomeConfig::compatibility_weight_coefficient)
-    //     .def_rw("conn_add_prob",
-    //         &DefaultGenomeConfig::conn_add_prob)
-    //     .def_rw("conn_delete_prob",
-    //         &DefaultGenomeConfig::conn_delete_prob)
-    //     .def_rw("node_add_prob",
-    //         &DefaultGenomeConfig::node_add_prob) 
-    //     .def_rw("node_delete_prob",
-    //         &DefaultGenomeConfig::node_delete_prob)
-    //     .def_rw("single_structural_mutation",
-    //         &DefaultGenomeConfig::single_structural_mutation)
-    //     .def_rw("structural_mutation_surer",
-    //         &DefaultGenomeConfig::structural_mutation_surer)
-    //     .def_rw("initial_connection",
-    //         &DefaultGenomeConfig::initial_connection)
-    //     .def_rw("connection_fraction",
-    //         &DefaultGenomeConfig::connection_fraction)
-    //     .def_rw("input_keys",
-    //         &DefaultGenomeConfig::input_keys)
-    //     .def_rw("output_keys",
-    //         &DefaultGenomeConfig::output_keys)
-    //     .def("get_new_node_key",
-    //         &DefaultGenomeConfig::get_new_node_key);
+    nb::class_<ConfigParameter>(m, "ConfigParameter")
+        .def(nb::init<
+                const std::string &,
+                const nb::object &,
+                std::optional<ConfigValue>
+            >(),
+            nb::arg("name"),
+            nb::arg("value_type"),
+            nb::arg("default") = std::nullopt
+        )
+        .def("repr", &ConfigParameter::repr)
+        // Now parse() takes (section: object, config_parser: object).
+        .def("parse", &ConfigParameter::parse,
+            nb::arg("section"), nb::arg("config_parser"))
+        .def("format", &ConfigParameter::format,
+            nb::arg("value"))
+        .def("interpret", &ConfigParameter::interpret,
+            nb::arg("config_dict"))
+        .def_rw("name", &ConfigParameter::name)
+        .def_rw("value_type", &ConfigParameter::value_type)
+        .def_rw("default", &ConfigParameter::default_value);
 
 
     nb::class_<GenomeConfig>(m, "GenomeConfig")
-        .def(nb::init<>())  // Default constructor
+        .def(nb::init<>())
         .def_rw("compatibility_weight_coefficient", &GenomeConfig::compatibility_weight_coefficient);
 
     nb::class_<DefaultNodeGene>(m, "DefaultNodeGene")
@@ -86,25 +57,4 @@ NB_MODULE(_neat3p, m) {
         .def_rw("key", &DefaultNodeGene::key)
         .def("copy", &DefaultNodeGene::copy)
         .def("distance", &DefaultNodeGene::distance);
-        // .def("mutate", &DefaultNodeGene::mutate);
-
-    // nb::class_<DefaultConnectionGene>(m, "DefaultConnectionGene")
-    //     .def(nb::init<>())
-    //     .def_rw("weight", &DefaultConnectionGene::weight)
-    //     .def_rw("enabled", &DefaultConnectionGene::enabled)
-    //     .def("copy", &DefaultConnectionGene::copy)
-    //     .def("distance", &DefaultConnectionGene::distance);
-    //     // .def("mutate", &DefaultConnectionGene::mutate)
-    //     // .def("crossover", &DefaultConnectionGene::crossover);
-
-    // nb::class_<DefaultGenome>(m, "DefaultGenome")
-    //     .def(nb::init<>())
-    //     .def_rw("key", &DefaultGenome::key)
-    //     .def_rw("fitness", &DefaultGenome::fitness)
-    //     .def_rw("nodes", &DefaultGenome::nodes)
-    //     .def_rw("connections", &DefaultGenome::connections)
-    //     .def("configure_new", &DefaultGenome::configure_new)
-    //     .def("mutate_add_node", &DefaultGenome::mutate_add_node);
-
-    // m.def("get_pruned_copy", &get_pruned_copy, "Get a pruned copy of the genome");
 }

--- a/src/neat3p/attributes.py
+++ b/src/neat3p/attributes.py
@@ -2,7 +2,7 @@
 
 from random import choice, gauss, randint, random, uniform
 
-from .config import ConfigParameter
+from ._neat3p import ConfigParameter
 
 # TODO: There is probably a lot of room for simplification of these classes using metaprogramming.
 

--- a/src/neat3p/config.py
+++ b/src/neat3p/config.py
@@ -4,78 +4,8 @@ import os
 import warnings
 from configparser import ConfigParser
 
+from ._neat3p import ConfigParameter
 
-class ConfigParameter(object):
-    """Contains information about one configuration item."""
-
-    def __init__(self, name, value_type, default=None):
-        self.name = name
-        self.value_type = value_type
-        self.default = default
-
-    def __repr__(self):
-        if self.default is None:
-            return f"ConfigParameter({self.name!r}, {self.value_type!r})"
-        return f"ConfigParameter({self.name!r}, {self.value_type!r}, {self.default!r})"
-
-    def parse(self, section, config_parser):
-        if int == self.value_type:
-            return config_parser.getint(section, self.name)
-        if bool == self.value_type:
-            return config_parser.getboolean(section, self.name)
-        if float == self.value_type:
-            return config_parser.getfloat(section, self.name)
-        if list == self.value_type:
-            v = config_parser.get(section, self.name)
-            return v.split(" ")
-        if str == self.value_type:
-            return config_parser.get(section, self.name)
-
-        raise RuntimeError(f"Unexpected configuration type: {self.value_type!r}")
-
-    def interpret(self, config_dict):
-        """
-        Converts the config_parser output into the proper type,
-        supplies defaults if available and needed, and checks for some errors.
-        """
-        value = config_dict.get(self.name)
-        if value is None:
-            if self.default is None:
-                raise RuntimeError("Missing configuration item: " + self.name)
-            else:
-                warnings.warn(f"Using default {self.default!r} for '{self.name!s}'", DeprecationWarning)
-                if (str != self.value_type) and isinstance(self.default, self.value_type):
-                    return self.default
-                else:
-                    value = self.default
-
-        try:
-            if str == self.value_type:
-                return str(value)
-            if int == self.value_type:
-                return int(value)
-            if bool == self.value_type:
-                if value.lower() == "true":
-                    return True
-                elif value.lower() == "false":
-                    return False
-                else:
-                    raise RuntimeError(self.name + " must be True or False")
-            if float == self.value_type:
-                return float(value)
-            if list == self.value_type:
-                return value.split(" ")
-        except Exception:
-            raise RuntimeError(
-                f"Error interpreting config item '{self.name}' with value {value!r} and type {self.value_type}"
-            )
-
-        raise RuntimeError("Unexpected configuration type: " + repr(self.value_type))
-
-    def format(self, value):
-        if list == self.value_type:
-            return " ".join(value)
-        return str(value)
 
 
 def write_pretty_params(f, config, params):

--- a/src/neat3p/genome.py
+++ b/src/neat3p/genome.py
@@ -46,7 +46,7 @@ class DefaultGenomeConfig(object):
             ConfigParameter("conn_delete_prob", float),
             ConfigParameter("node_add_prob", float),
             ConfigParameter("node_delete_prob", float),
-            ConfigParameter("single_structural_mutation", bool, "false"),
+            ConfigParameter("single_structural_mutation", bool, False),
             ConfigParameter("structural_mutation_surer", str, "default"),
             ConfigParameter("initial_connection", str, "unconnected"),
         ]

--- a/tests/test_config_save_restore.py
+++ b/tests/test_config_save_restore.py
@@ -49,9 +49,9 @@ class ConfigTests(unittest.TestCase):
 
         self.assertEqual(names1, names2)
 
-        for n in names1:
-            v1 = getattr(config1, n)
-            v2 = getattr(config2, n)
+        for name in names1:
+            v1 = getattr(config1, name)
+            v2 = getattr(config2, name)
             self.assertEqual(v1, v2)
 
     def test_config_save_restore1(self):


### PR DESCRIPTION
This pull request includes significant changes to the configuration handling in the project. The primary focus is on the introduction of a new `ConfigParameter` class implemented in C++ and its integration throughout the codebase. The changes also involve removing the old Python-based `ConfigParameter` class and updating relevant parts of the code to use the new implementation.

### Configuration Handling Updates:

* [`src/config.hpp`](diffhunk://#diff-7d36a3982a659a42ce27f280729500523eb3cbe86ffdc80713f6b4aa83cc44d0R1-R208): Introduced a new `ConfigParameter` class in C++ to handle configuration parameters with support for various data types and integration with Python using nanobind.
* [`src/neat3p.cpp`](diffhunk://#diff-e78f1d6884c351ef4bf57b88dd7199288dd560864eb902eda478addd0e97f63fR12-L109): Updated the module to bind the new `ConfigParameter` class, enabling its use in Python code. Removed old commented-out code related to genome configuration.

### Code Refactoring:

* [`src/neat3p/config.py`](diffhunk://#diff-36a15b245f9b1d95806520bb8ef626eaf847453802860bb5f148ca5c4ba41c3bR7-L78): Replaced the old Python-based `ConfigParameter` class with the new C++ implementation. This change simplifies the codebase by removing redundant code.
* [`src/neat3p/attributes.py`](diffhunk://#diff-f220966cbacce21f4d7dd8a005f994fb7a793bd20fec1d4e8ff57a1d48ba474fL5-R5): Updated the import statement to use the new `ConfigParameter` class from the C++ module.

### Bug Fixes and Improvements:

* [`src/neat3p/genome.py`](diffhunk://#diff-5e797bffc4a41ceb7577bc40da64bba371e8078d61bed798621fa2ae14e30fd2L49-R49): Fixed the default value for the `single_structural_mutation` parameter to use a boolean `False` instead of the string "false".
* [`tests/test_config_save_restore.py`](diffhunk://#diff-84208b9d361c7c7dcde2412afd47d78e4beb4b05256e810247365f139638f640L52-R54): Improved variable naming in the test to enhance readability and consistency.