### PR TITLE
[Feature#18] Refactor dockerfile to use Ubuntu24.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,8 @@ find_package(nanobind CONFIG REQUIRED)
 
 find_package(msgpack REQUIRED)
 
-add_compile_definitions(SPDLOG_HEADER_ONLY)
 find_package(spdlog REQUIRED)
+message(STATUS "→ spdlog version:     ${spdlog_VERSION}")
 
 # find_package(nanobind CONFIG REQUIRED)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,58 @@
-# Base image
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM ubuntu:24.04
 
-# System tools
-RUN yum install -y \
-      wget \
-      bzip2 \
-      git \
-      gcc-c++ \
-      cmake3 \
-      make \
-      ninja-build \
-    #   lmdb \
-    #   lmdb-devel \
-    && yum clean all
+# avoid prompts during apt installs
+ARG DEBIAN_FRONTEND=noninteractive
 
-# Build & install flatbuffers
-ARG FLATBUFFERS_VERSION=23.5.26
+# 1) Install system build tools + dev‐libs
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        wget \
+        bzip2 \
+        ca-certificates \
+        git \
+        build-essential \
+        cmake \
+        ninja-build \
+        pkg-config \
+        libmsgpack-dev \
+        libmsgpack-cxx-dev \
+        libspdlog-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2) Build & install FlatBuffers
+ARG FLATBUFFERS_VERSION=24.3.25
 RUN git clone --depth 1 -b v${FLATBUFFERS_VERSION} \
       https://github.com/google/flatbuffers.git /tmp/flatbuffers \
- && mkdir /tmp/flatbuffers/build \
- && cd /tmp/flatbuffers/build \
- && cmake3 \
-     -DFLATBUFFERS_BUILD_TESTS=OFF \
-     -DFLATBUFFERS_BUILD_CPP17=ON \
-     -DCMAKE_BUILD_TYPE=Release \
-     -DFLATBUFFERS_ENABLE_PCH=ON \
-     -DCMAKE_INSTALL_PREFIX=/usr/local \
-     -DCMAKE_INSTALL_LIBDIR=lib \
-     .. \
- && make -j"$(nproc)" \
- && make install \
- && rm -rf /tmp/flatbuffers
+    && mkdir /tmp/flatbuffers/build \
+    && cd /tmp/flatbuffers/build \
+    && cmake \
+        -DFLATBUFFERS_BUILD_TESTS=OFF \
+        -DFLATBUFFERS_BUILD_CPP17=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DFLATBUFFERS_ENABLE_PCH=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        .. \
+    && make -j"$(nproc)" install \
+    && rm -rf /tmp/flatbuffers
 
-# Ensure flatc is on PATH
+# ensure flatc is on PATH
 ENV PATH="/usr/local/bin:${PATH}"
 
-# Miniconda installation
+# 3) Install Miniconda
 ENV CONDA_DIR=/opt/conda
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
       -O /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -b -p $CONDA_DIR \
     && rm /tmp/miniconda.sh \
-    && $CONDA_DIR/bin/conda init bash \
+    # config conda for strict, non-interactive installs
     && $CONDA_DIR/bin/conda config --set always_yes yes --set changeps1 no \
+    && $CONDA_DIR/bin/conda config --set channel_priority strict \
     && $CONDA_DIR/bin/conda update -q conda
 
-# Update PATH
 ENV PATH="$CONDA_DIR/bin:$PATH"
 
-# Copy environment spec
+# 4) Copy in your environment spec
 WORKDIR /project
 COPY . /project/
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ isort==5.13.2
 Sphinx==8.1.3
 ruff==0.9.5
 pytest==8.3.5
+build==1.2.2


### PR DESCRIPTION
This pull request includes updates to the build system, Dockerfile, and development dependencies to modernize the environment and improve compatibility. The most significant changes include switching the base image in `Dockerfile` to Ubuntu 24.04, adding a version message for `spdlog`, and updating the development requirements.

### Build system updates:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL53-R54): Added a status message to display the `spdlog` version during the build process, improving visibility into the build configuration.

### Dockerfile modernization:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R55): Replaced the base image `quay.io/pypa/manylinux2014_x86_64` with `ubuntu:24.04` and updated the system tools installation process to use `apt-get` instead of `yum`. This change includes installing necessary development libraries (`libmsgpack-dev`, `libspdlog-dev`) and tools (`build-essential`, `cmake`). Additionally, updated the FlatBuffers version to `24.3.25` and streamlined the Miniconda installation process.

### Development dependencies:
* [`dev-requirements.txt`](diffhunk://#diff-43470c4f399e798afc682f0bf6c690eef5f47ee25445904a066e4c3314f3a787R6): Added `build==1.2.2` to the development requirements, likely to support Python package building tasks.