### PR TITLE
Fix typo in DistributedEvaluator docs

### DIFF
--- a/src/neat3p/distributed.py
+++ b/src/neat3p/distributed.py
@@ -358,7 +358,7 @@ class DistributedEvaluator(object):
         ``num_workers`` is the number of child processes to use if in secondary
         mode. It defaults to None, which means `multiprocessing.cpu_count()`
         is used to determine this value. If 1 in a secondary node, the process creating
-        the DistributedEvaluator instance will also do the evaulations.
+        the DistributedEvaluator instance will also do the evaluations.
         ``worker_timeout`` specifies the timeout (in seconds) for a secondary node
         getting the results from a worker subprocess; if None, there is no timeout.
         ``mode`` specifies the mode to run in; it defaults to MODE_AUTO.


### PR DESCRIPTION
## Summary
- correct a small spelling error in the `DistributedEvaluator.__init__` docstring

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68407c015e8c8321b3c08c71f572c262