### PR TITLE
[feature#293] RecurrentNet: fix GPU device propagation + expand __all__

### DIFF
--- a/.claude/rules/specs-folder-convention.md
+++ b/.claude/rules/specs-folder-convention.md
@@ -1,0 +1,58 @@
+# Specs Folder Convention — neat3p
+
+Adapted from the lifesim sibling repo's rule of the same name. For the detailed
+authoring guide (header block, section structure, house style) see the
+`writing-specs` skill in this repo (`.claude/skills/writing-specs/SKILL.md`) —
+this rule is the short, always-on summary.
+
+All design documents, research notes, and implementation plans for neat3p live
+under `specs/`.
+
+> **Key difference from the lifesim sibling repo: neat3p `specs/` is COMMITTED**
+> — version-controlled, reviewable history, not scratch. (In lifesim, `specs/`
+> is gitignored/local-only. Don't carry that habit across — here you *do* commit
+> specs.)
+
+---
+
+## Folder naming
+
+One folder per epic/ticket/topic, **date-prefixed**:
+
+```
+specs/<YYYYMMDD>-<kebab-topic>/
+```
+
+Examples already in the repo:
+- `specs/20260613-module-reorganization/`
+- `specs/20260615-benchmark-module-refactor/`
+- `specs/20260616-3d-spatial-input-compression/`
+
+The date is the **creation** date (when the folder was started), not the last
+edit. Topic is short kebab-case describing the work, not the issue number.
+
+---
+
+## File naming inside a folder
+
+| File | Purpose |
+|------|---------|
+| `research.md` | Investigation findings, root-cause analysis, options compared, recommendation |
+| `plan.md` | The chosen approach: problem, architecture, target layout, incremental steps, risks |
+| `research-<topic>.md` / `plan-<topic>.md` | Only when a folder genuinely needs multiple docs of the same type |
+
+Use `research.md` and `plan.md` as defaults. A topic often has both: research
+explores, plan commits.
+
+---
+
+## What goes here vs elsewhere
+
+- **`specs/`** — design intent, investigation results, architectural decisions (committed).
+- **`.claude/rules/`** — persistent always-on workflow rules for Claude (like this file).
+- **`.claude/skills/`** — invokable how-to guides (e.g. `writing-specs`).
+- **Git commit messages / PR bodies** — the *why* behind a specific landed change.
+- **Code comments** — only when a non-obvious invariant or workaround needs explanation.
+
+Do **not** put ephemeral task notes, in-progress checklists, or session summaries
+in `specs/`. Those belong in the conversation or a task tracker.

--- a/src/neat3p/__init__.py
+++ b/src/neat3p/__init__.py
@@ -20,4 +20,22 @@ from .statistics import StatisticsReporter
 from .threaded import ThreadedEvaluator
 from .utils import this_is_neat
 
-__all__ = ["GenomeConfig", "DefaultNodeGene"]
+__all__ = [
+    "GenomeConfig",
+    "DefaultNodeGene",
+    "Checkpointer",
+    "Config",
+    "DistributedEvaluator",
+    "host_is_local",
+    "DefaultGenome",
+    "ParallelEvaluator",
+    "CompleteExtinctionException",
+    "Population",
+    "StdOutReporter",
+    "DefaultReproduction",
+    "DefaultSpeciesSet",
+    "DefaultStagnation",
+    "StatisticsReporter",
+    "ThreadedEvaluator",
+    "this_is_neat",
+]

--- a/src/neat3p/nn/composite/feature_attention.py
+++ b/src/neat3p/nn/composite/feature_attention.py
@@ -109,7 +109,7 @@ class NEATNetWithFeatureAttention(nn.Module):
                     p.requires_grad_(False)
             self._compile_feature_attn()
 
-        self.net = RecurrentNet.create(genome, config)
+        self.net = RecurrentNet.create(genome, config, device=str(self.device))
 
         owned_params = ([] if encoder is not None else list(self.compiled_encoder.parameters())) + (
             [] if attn is not None else list(self.compiled_feature_attn.parameters())

--- a/src/neat3p/nn/composite/neat_recurrent.py
+++ b/src/neat3p/nn/composite/neat_recurrent.py
@@ -41,7 +41,9 @@ class NEATRecurrentNet(nn.Module):
         self.state_dim = state_dim
         self.action_dim = action_dim
         self.explore_rate = 0.125
-        self.net = RecurrentNet.create(genome, config, use_current_activs=use_current_activs)
+        self.net = RecurrentNet.create(
+            genome, config, use_current_activs=use_current_activs, device=str(self.device)
+        )
 
     def forward(self, state: torch.Tensor) -> torch.Tensor:
         state = state.to(self.device)

--- a/src/neat3p/nn/phenotypes/recurrent_net.py
+++ b/src/neat3p/nn/phenotypes/recurrent_net.py
@@ -7,13 +7,15 @@ from neat3p.graphs import required_for_output
 from neat3p.nn.modules.activations import sigmoid_activation
 
 
-def dense_from_coo(shape, conns, dtype=torch.float64):
-    mat = torch.zeros(shape, dtype=dtype)
+def dense_from_coo(shape, conns, dtype=torch.float64, device="cpu"):
+    mat = torch.zeros(shape, dtype=dtype, device=device)
     idxs, weights = conns
     if len(idxs) == 0:
         return mat
     rows, cols = np.array(idxs).transpose()
-    mat[torch.tensor(rows), torch.tensor(cols)] = torch.tensor(weights, dtype=dtype)
+    mat[torch.tensor(rows, device=device), torch.tensor(cols, device=device)] = torch.tensor(
+        weights, dtype=dtype, device=device
+    )
     return mat
 
 
@@ -49,26 +51,26 @@ class RecurrentNet:
         self.activation = activation
         self.n_internal_steps = n_internal_steps
         self.dtype = dtype
-        self.device = device
+        self.device = torch.device(device)
 
         self.n_inputs = n_inputs
         self.n_hidden = n_hidden
         self.n_outputs = n_outputs
 
         if n_hidden > 0:
-            self.input_to_hidden = dense_from_coo((n_hidden, n_inputs), input_to_hidden, dtype=dtype)
-            self.hidden_to_hidden = dense_from_coo((n_hidden, n_hidden), hidden_to_hidden, dtype=dtype)
-            self.output_to_hidden = dense_from_coo((n_hidden, n_outputs), output_to_hidden, dtype=dtype)
-            self.hidden_to_output = dense_from_coo((n_outputs, n_hidden), hidden_to_output, dtype=dtype)
-        self.input_to_output = dense_from_coo((n_outputs, n_inputs), input_to_output, dtype=dtype)
-        self.output_to_output = dense_from_coo((n_outputs, n_outputs), output_to_output, dtype=dtype)
+            self.input_to_hidden = dense_from_coo((n_hidden, n_inputs), input_to_hidden, dtype=dtype, device=self.device)
+            self.hidden_to_hidden = dense_from_coo((n_hidden, n_hidden), hidden_to_hidden, dtype=dtype, device=self.device)
+            self.output_to_hidden = dense_from_coo((n_hidden, n_outputs), output_to_hidden, dtype=dtype, device=self.device)
+            self.hidden_to_output = dense_from_coo((n_outputs, n_hidden), hidden_to_output, dtype=dtype, device=self.device)
+        self.input_to_output = dense_from_coo((n_outputs, n_inputs), input_to_output, dtype=dtype, device=self.device)
+        self.output_to_output = dense_from_coo((n_outputs, n_outputs), output_to_output, dtype=dtype, device=self.device)
 
         if n_hidden > 0:
             self.hidden_responses = torch.tensor(hidden_responses, dtype=dtype, device=self.device)
             self.hidden_biases = torch.tensor(hidden_biases, dtype=dtype, device=self.device)
 
-        self.output_responses = torch.tensor(output_responses, dtype=dtype)
-        self.output_biases = torch.tensor(output_biases, dtype=dtype, device=device)
+        self.output_responses = torch.tensor(output_responses, dtype=dtype, device=self.device)
+        self.output_biases = torch.tensor(output_biases, dtype=dtype, device=self.device)
 
         self.reset(batch_size)
 
@@ -77,28 +79,17 @@ class RecurrentNet:
             self.activs = torch.zeros(batch_size, self.n_hidden, dtype=self.dtype, device=self.device)
         else:
             self.activs = None
-        self.outputs = torch.zeros(batch_size, self.n_outputs, dtype=self.dtype)
+        self.outputs = torch.zeros(batch_size, self.n_outputs, dtype=self.dtype, device=self.device)
 
     def activate(self, inputs):
         """
         inputs: (batch_size, n_inputs)
         returns: (batch_size, n_outputs)
         """
-        self.input_to_output = self.input_to_output.cuda()
-        self.output_to_output = self.output_to_output.cuda()
-        self.outputs = self.outputs.cuda()
-        self.output_responses = self.output_responses.cuda()
-        self.output_biases = self.output_biases.cuda()
-
         with torch.no_grad():
-            inputs = torch.tensor(inputs, dtype=self.dtype, device=self.device)
-            activs_for_output = self.activs.cuda() if self.activs is not None else self.activs
+            inputs = inputs.to(device=self.device, dtype=self.dtype)
+            activs_for_output = self.activs
             if self.n_hidden > 0:
-                self.input_to_hidden = self.input_to_hidden.cuda()
-                self.hidden_to_hidden = self.hidden_to_hidden.cuda()
-                self.output_to_hidden = self.output_to_hidden.cuda()
-                self.hidden_to_output = self.hidden_to_output.cuda()
-
                 for _ in range(self.n_internal_steps):
                     self.activs = self.activation(
                         self.hidden_responses
@@ -110,7 +101,7 @@ class RecurrentNet:
                         + self.hidden_biases
                     )
                 if self.use_current_activs:
-                    activs_for_output = self.activs.cuda() if self.activs is not None else self.activs
+                    activs_for_output = self.activs
             output_inputs = self.input_to_output.mm(inputs.t()).t() + self.output_to_output.mm(self.outputs.t()).t()
             if self.n_hidden > 0:
                 output_inputs += self.hidden_to_output.mm(activs_for_output.t()).t()
@@ -126,6 +117,7 @@ class RecurrentNet:
         prune_empty=False,
         use_current_activs=False,
         n_internal_steps=1,
+        device="cuda",
     ):
         genome_config = config.genome_config
         required = required_for_output(genome_config.input_keys, genome_config.output_keys, genome.connections)
@@ -221,6 +213,7 @@ class RecurrentNet:
             activation=activation,
             use_current_activs=use_current_activs,
             n_internal_steps=n_internal_steps,
+            device=device,
         )
 
 
@@ -338,6 +331,7 @@ class OptimizedRecurrentNet:
         prune_empty=False,
         use_current_activs=False,
         n_internal_steps=1,
+        device="cuda",
     ):
         genome_config = config.genome_config
         required = required_for_output(genome_config.input_keys, genome_config.output_keys, genome.connections)
@@ -433,4 +427,5 @@ class OptimizedRecurrentNet:
             activation=activation,
             use_current_activs=use_current_activs,
             n_internal_steps=n_internal_steps,
+            device=device,
         )


### PR DESCRIPTION
## Summary

- Removes the scattered `.cuda()` calls in `RecurrentNet.activate()` that were a post-hoc workaround for tensors always being created on CPU.
- Threads `device` from `RecurrentNet.create()` / `OptimizedRecurrentNet.create()` into `__init__` and `dense_from_coo` so all weight matrices and state tensors land on the right device at allocation time.
- Composite wrappers (`NEATNetWithFeatureAttention`, `NEATRecurrentNet`) now pass `device=str(self.device)` to `create()`.
- Expands `__init__.__all__` to cover all public symbols.
- Adds `.claude/rules/specs-folder-convention.md`.

Closes https://github.com/arthurmoreno/life-simulation/issues/293
Part of https://github.com/arthurmoreno/life-simulation/issues/281

## Test plan

- [ ] Run benchmark suite on CPU: `make benchmark` — all nets activate without device mismatch errors
- [ ] Run benchmark suite on CUDA GPU: verify no `.cuda()` calls remain in hot path
- [ ] Smoke-test `NEATNetWithFeatureAttention` and `NEATRecurrentNet` forward passes on both CPU and CUDA

🤖 Generated with [Claude Code](https://claude.com/claude-code)